### PR TITLE
Link with libm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ SOURCES= sassc.c
 OBJECTS = $(SOURCES:.c=.o)
 
 sassc: $(OBJECTS) libsass.a
-	gcc -O2 -o $(BIN_DIR)/sassc sassc.o $(SRC_DIR)/libsass.a -lstdc++
+	gcc -O2 -o $(BIN_DIR)/sassc sassc.o $(SRC_DIR)/libsass.a -lstdc++ -lm
 
 libsass.a: force_look
 	cd $(SRC_DIR); $(MAKE)


### PR DESCRIPTION
On my Fedora linux system I need to pass -lm to compile.

Before:

``` bash
make[1]: Leaving directory `/home/retro/work/fun/sassc/libsass'
gcc -O2 -o bin/sassc sassc.o libsass/libsass.a -lstdc++
/usr/bin/ld: libsass/libsass.a(functions.o): undefined reference to symbol 'floor@@GLIBC_2.2.5'
/usr/bin/ld: note: 'floor@@GLIBC_2.2.5' is defined in DSO /lib64/libm.so.6 so try adding it to the linker command line
/lib64/libm.so.6: could not read symbols: Invalid operation
collect2: ld returned 1 exit status
make: *** [sassc] Error 1
```
