### PR TITLE
Clean up .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,7 @@
-src/Makefile
-.DS_Store
-tmp/
-.sass-cache
-sassc
-build/*
-*.o
-*.a
-a.out
 bin/*
+*.o
 *.gem
+.sass-cache
+
+a.out
+.DS_Store


### PR DESCRIPTION
This just removes a few old entries from `.gitignore` and puts the non-project-specific stuff at the bottom.
