### PR TITLE
Command option improvements

### DIFF
--- a/sassc.c
+++ b/sassc.c
@@ -181,16 +181,12 @@ int main(int argc, char** argv) {
         }
     }
 
-    if(optind > argc - 1) {
-        fprintf(stderr, "Error: You must supply a FILE argument.\n");
-        invalid_usage(argv[0]);
-    }
-    else if(optind < argc - 1) {
+    if(optind < argc - 1) {
         fprintf(stderr, "Error: Too many arguments.\n");
         invalid_usage(argv[0]);
     }
 
-    if(strcmp(argv[optind], "-") != 0) {
+    if(optind < argc && strcmp(argv[optind], "-") != 0) {
         return compile_file(options, argv[optind], outfile);
     } else {
         return compile_stdin(options, outfile);


### PR DESCRIPTION
This pull request contains 3 changes to the command options (split into a series of organized commits):
1. The `-s` flag is removed. Instead, a file name of `-` (dash) can be used to read from standard input. This is a very common convention (used by `grep`, `cat`, `awk`, etc...)
2. An `-o` flag is added, to specify an output file that should be written to (instead of writing to standard output). Writing to standard output is still supported, by omitting this flag.
3. An `-h` flag is added for displaying a help message, detailing all the available options and how to use the program. This is what it currently outputs:
   
   ```
   $ sassc -h
   Usage: sassc [OPTIONS] FILE
   Options:
     -o OUTFILE               File to save the output. If not supplied will write to standard output.
     -t NAME                  Output style. Can be: compressed compact expanded nested.
     -l                       Emit comments in the generated CSS indicating the corresponding source line.
     -I PATH                  Sass import path.
     -h                       Display help message.
   
   Specify a file name of - (dash) to read from standard input.
   ```
