### PR TITLE
fix code blocks in documentation

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -50,9 +50,9 @@ The official libsass/sassc test suite is located at http://github.com/hcatlin/sa
 
 For instance, this is in my profile.
 
-  export SASS_SPEC_PATH=/Users/hcatlin/dev/sass/sass-spec
-  export SASS_SASSC_PATH=/Users/hcatlin/dev/sass/sassc
-  export SASS_LIBSASS_PATH=/Users/hcatlin/dev/sass/libsass
+    export SASS_SPEC_PATH=/Users/hcatlin/dev/sass/sass-spec
+    export SASS_SASSC_PATH=/Users/hcatlin/dev/sass/sassc
+    export SASS_LIBSASS_PATH=/Users/hcatlin/dev/sass/libsass
 
 Then, run the SassC specific tests this way:
 


### PR DESCRIPTION
I opted not to use fenced blocks, for consistency and compatibility
