### PR TITLE
Show a helpful error message when SASS_LIBSASS_PATH isn't defined.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,11 @@ $(TARGET): $(OBJECTS) $(SASS_LIBSASS_PATH)/libsass.a
 
 $(SASS_LIBSASS_PATH)/libsass.a: libsass
 libsass:
+ifdef SASS_LIBSASS_PATH
 	$(MAKE) -C $(SASS_LIBSASS_PATH)
+else
+	$(error SASS_LIBSASS_PATH must be defined)
+endif
 
 %.o: %.c
 	$(CC) -c $(CFLAGS) $< -o $@


### PR DESCRIPTION
Otherwise, you just get an unhelpful error message like this:

```
make: option requires an argument -- C
```
