### PR TITLE
Fix default Makefile with clang on Travis.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-CC = gcc
+CC ?= gcc
 CFLAGS = -Wall -O2 -I $(SASS_LIBSASS_PATH)
 LDFLAGS = -O2
 LDLIBS = -lstdc++ -lm 


### PR DESCRIPTION
As pointed out in hcatlin/libsass#229, the default Makefile will not use clang when building on Travis because it overrides the environment variable.
