### PR TITLE
Aligns build system with autotools build and travis-ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,15 +4,15 @@ compiler:
   - gcc
   - clang
 
+env:
+  - AUTOTOOLS=no BUILD=shared
+  - AUTOTOOLS=no BUILD=static
+
 before_install:
   - gem install sass
   - git clone https://github.com/sass/libsass.git
   - cd libsass && git submodule init && git submodule update && cd ..
   - export SASS_LIBSASS_PATH=libsass
-  - sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
-  - sudo apt-get update -qq
-  - if [ "$CXX" = "g++" ]; then sudo apt-get install -qq g++-4.8; fi
-  - if [ "$CXX" = "g++" ]; then export CXX="g++-4.8" CC="gcc-4.8"; fi
 
 script:
   - make test


### PR DESCRIPTION
This PR is linked to https://github.com/sass/libsass/pull/606
Will not pass travis ci until both PRs are merged!

Improves the build system to support shared object linking.
Drops the need for newer gcc as it now uses `-std=c++0x`

Implements BUILD variable to link shared or static objects.
Expects libraries in lib directory as with autotools build.

https://travis-ci.org/mgreter/libsass/builds/39788451

Thanks to @QuLogic for his reviews in https://github.com/sass/libsass/pull/606
