### PR TITLE
Implement API to fetch compiled version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ compiler:
 env:
   - AUTOTOOLS=no BUILD=shared
   - AUTOTOOLS=no BUILD=static
+  - AUTOTOOLS=yes BUILD=shared
+  - AUTOTOOLS=yes BUILD=static
 
 before_install:
   - gem install sass
@@ -15,7 +17,8 @@ before_install:
   - export SASS_LIBSASS_PATH=libsass
 
 script:
-  - make test
+  - ./script/ci-build-libsass
 
 after_success:
   - ./bin/sassc -v
+  - ldd ./bin/sassc

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,10 @@
-CC ?= gcc
+CC       ?= cc
+CXX      ?= g++
+RM       ?= rm -f
+MKDIR    ?= mkdir -p
+CFLAGS   ?= -Wall -fPIC -O2
+CXXFLAGS ?= -Wall -fPIC -O2
+LDFLAGS  ?= -Wall -fPIC -O2
 
 ifeq "$(SASSC_VERSION)" ""
   ifneq "$(wildcard ./.git/ )" ""
@@ -6,35 +12,55 @@ ifeq "$(SASSC_VERSION)" ""
   endif
 endif
 
-SASSC_VERSION ?= [NA]
+ifneq "$(SASSC_VERSION)" ""
+  CFLAGS   += -DSASSC_VERSION="\"$(SASSC_VERSION)\""
+  CXXFLAGS += -DSASSC_VERSION="\"$(SASSC_VERSION)\""
+endif
 
-CFLAGS = -DSASSC_VERSION="\"$(SASSC_VERSION)\"" -Wall -O2 -I $(SASS_LIBSASS_PATH) $(EXTRA_CFLAGS)
-LDFLAGS = -O2 $(EXTRA_LDFLAGS)
+# enable mandatory flag
+CXXFLAGS += -std=c++0x
+LDFLAGS  += -std=c++0x
+
+ifneq "$(SASS_LIBSASS_PATH)" ""
+  CFLAGS   += -I $(SASS_LIBSASS_PATH)
+  CXXFLAGS += -I $(SASS_LIBSASS_PATH)
+endif
+
+ifneq "$(EXTRA_CFLAGS)" ""
+  CFLAGS   += $(EXTRA_CFLAGS)
+endif
+ifneq "$(EXTRA_CXXFLAGS)" ""
+  CXXFLAGS += $(EXTRA_CXXFLAGS)
+endif
+ifneq "$(EXTRA_LDFLAGS)" ""
+  LDFLAGS  += $(EXTRA_LDFLAGS)
+endif
 
 ifneq (,$(findstring /cygdrive/,$(PATH)))
 	UNAME := Cygwin
 else
-ifneq (,$(findstring WINDOWS,$(PATH)))
-	UNAME := Windows
-else
-	UNAME := $(shell uname -s)
-endif
+	ifneq (,$(findstring WINDOWS,$(PATH)))
+		UNAME := Windows
+	else
+		UNAME := $(shell uname -s)
+	endif
 endif
 
+LDLIBS = -lstdc++ -lm
 ifeq ($(UNAME),Darwin)
-	LDLIBS = -lstdc++ -lm -stdlib=libc++
-else
-	LDLIBS = -lstdc++ -lm
+	CFLAGS += -stdlib=libc++
+	CXXFLAGS += -stdlib=libc++
+	LDFLAGS += -stdlib=libc++
+endif
+
+ifneq ($(BUILD), shared)
+	BUILD = static
 endif
 
 SOURCES = sassc.c
 OBJECTS = $(SOURCES:.c=.o)
 TARGET = bin/sassc
 SPEC_PATH = $(SASS_SPEC_PATH)
-
-ifneq ($(BUILD), shared)
-	BUILD = static
-endif
 
 all: libsass $(TARGET)
 
@@ -70,6 +96,7 @@ endif
 
 test: all
 	bin/sassc -h
+	bin/sassc -v
 
 clean:
 	rm -f $(OBJECTS) $(TARGET)

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,6 +1,27 @@
 ACLOCAL_AMFLAGS = -I m4
 
+AM_LDFLAGS =
+AM_CFLAGS = -Wall -fPIC
+AM_CXXFLAGS = -Wall -fPIC
+AM_CFLAGS += -DSASSC_VERSION="\"$(SASSC_VERSION)\""
+AM_CXXFLAGS += -DSASSC_VERSION="\"$(SASSC_VERSION)\""
+
+AM_CXXFLAGS += -std=c++0x
+AM_LDFLAGS += -std=c++0x
+
+LDLIBS = -lstdc++ -lm
+
+if ENABLE_COVERAGE
+  AM_CFLAGS += -O0 --coverage
+  AM_CXXFLAGS += -O0 --coverage
+  AM_LDFLAGS += -O0 --coverage -lgcov
+else
+  AM_CFLAGS += -O2
+  AM_CXXFLAGS += -O2
+endif
+
 bin_PROGRAMS = sassc
 sassc_SOURCES = sassc.c
-sassc_CPPFLAGS = $(LIBSASS_CFLAGS)
-sassc_LDFLAGS= $(LIBSASS_LIBS)
+sassc_CFLAGS = $(AM_CFLAGS) $(LIBSASS_CFLAGS)
+sassc_CXXFLAGS = $(AM_CXXFLAGS) $(LIBSASS_CFLAGS)
+sassc_LDFLAGS= $(AM_LDFLAGS) $(LIBSASS_LIBS) $(LDLIBS)

--- a/configure.ac
+++ b/configure.ac
@@ -20,6 +20,59 @@ AC_SUBST([LIBSASS_LIBS])
 
 LT_INIT
 AC_PROG_CXX
+
+AC_CHECK_HEADERS([sass.h])
+AC_CHECK_HEADERS([sass2scss.h])
+AC_CHECK_HEADERS([sass_values.h])
+AC_CHECK_HEADERS([sass_context.h])
+AC_CHECK_HEADERS([sass_functions.h])
 AC_CHECK_HEADERS([sass_interface.h])
+
+AC_ARG_ENABLE([coverage],
+  [AS_HELP_STRING([--enable-coverage],
+    [enable coverage report for test suite])],
+    [enable_cov=$enableval],
+    [enable_cov=no])
+
+if test "x$enable_cov" = "xyes"; then
+
+    AC_CHECK_PROG(GCOV, gcov, gcov)
+
+    # Remove all optimization flags from C[XX]FLAGS
+    changequote({,})
+    CFLAGS=`echo "$CFLAGS" | $SED -e 's/-O[0-9]*//g'`
+    CXXFLAGS=`echo "$CXXFLAGS" | $SED -e 's/-O[0-9]*//g'`
+    changequote([,])
+
+    AC_SUBST(GCOV)
+fi
+
+AM_CONDITIONAL(ENABLE_COVERAGE, test "x$enable_cov" = "xyes")
+
+AC_ARG_VAR(SASSC_VERSION, libsass version)
+if test "x$SASSC_VERSION" = "x"; then
+  AC_CHECK_PROG(GIT, git, git)
+  if test "x$GIT" = "x"; then
+    AC_MSG_ERROR([Unable to find git binary to query version.
+You can solve this by setting SASSC_VERSION:
+# export SASSC_VERSION="x.y.z"
+])
+  else
+    AC_CHECK_FILE(.git/config, [], [
+    AC_MSG_ERROR([Unable to find .git directory to query version.
+You can solve this by setting SASSC_VERSION:
+# export SASSC_VERSION="x.y.z"
+])
+    ])
+    SASSC_VERSION=`$GIT describe --abbrev=4 --dirty --always --tags`
+  fi
+  if test "x$SASSC_VERSION" = "x"; then
+    AC_MSG_ERROR([SASSC_VERSION not defined.
+You can solve this by setting SASSC_VERSION:
+# export SASSC_VERSION="x.y.z"
+])
+  fi
+fi
+
 AC_CONFIG_FILES([Makefile])
 AC_OUTPUT

--- a/sassc.c
+++ b/sassc.c
@@ -5,6 +5,10 @@
 #include <sass2scss.h>
 #include <sass_interface.h>
 
+#ifndef SASSC_VERSION
+#define SASSC_VERSION "[NA]"
+#endif
+
 #define BUFSIZE 512
 #ifdef _WIN32
 #define PATH_SEP ';'
@@ -122,15 +126,9 @@ struct
     sizeof(style_option_strings) / sizeof(style_option_strings[0])
 
 void print_version(char* argv0) {
-    printf("sassc: ");
-    printf(SASSC_VERSION);
-    printf("\n");
-    printf("libsass: ");
-    printf(libsass_version());
-    printf("\n");
-    printf("sass2scss: ");
-    printf(sass2scss_version());
-    printf("\n");
+    printf("sassc: %s\n", SASSC_VERSION);
+    printf("libsass: %s\n", libsass_version());
+    printf("sass2scss: %s\n", sass2scss_version());
 }
 
 void print_usage(char* argv0) {

--- a/script/ci-build-libsass
+++ b/script/ci-build-libsass
@@ -1,0 +1,89 @@
+#!/bin/bash
+
+set -e
+
+# script/bootstrap
+
+# export this path right here (was in script/spec before)
+export SASS_SASSC_PATH="$( cd "$( dirname "${BASH_SOURCE[0]}" )"/../ && pwd )"
+
+# use some defaults if not running under travis ci
+if [ "x$TRAVIS_BUILD_DIR" == "x" ]; then export TRAVIS_BUILD_DIR=$(pwd)/build; fi
+if [ "x$SASS_LIBSASS_PATH" == "x" ]; then export SASS_SASSC_PATH=$(pwd)/libsass; fi
+if [ "x$SASS_SPEC_PATH" == "x" ]; then export SASS_SPEC_PATH=$(pwd)/sass-spec; fi
+
+if [ "x$COVERAGE" == "xyes" ]; then
+  COVERAGE_OPT="--enable-coverage"
+  export EXTRA_CFLAGS="-O0 --coverage"
+  export EXTRA_CXXFLAGS="-O0 --coverage"
+  export EXTRA_LDFLAGS="-O0 --coverage"
+else
+  COVERAGE_OPT="--disable-coverage"
+fi
+
+if [ "x$BUILD" == "xstatic" ]; then
+  SHARED_OPT="--disable-shared --enable-static"
+  MAKE_TARGET="static"
+else
+  # Makefile of sassc wants to link to static
+  SHARED_OPT="--enable-shared --enable-static"
+  MAKE_TARGET="shared"
+fi
+
+MAKE_OPTS="$MAKE_OPTS -j3 V=1"
+
+if [ "x$AUTOTOOLS" == "xyes" ]; then
+
+  pushd $SASS_LIBSASS_PATH
+  echo -en 'travis_fold:start:libsass\r'
+
+  autoreconf --force --install
+  ./configure --disable-tests $COVERAGE_OPT \
+    --disable-silent-rules \
+    --prefix=$TRAVIS_BUILD_DIR \
+    ${SHARED_OPT}
+
+  # always rebuild
+  make $MAKE_OPTS clean
+
+  # install the library
+  make $MAKE_OPTS install
+
+  echo -en 'travis_fold:end:libsass\r'
+  popd
+
+  echo -en 'travis_fold:start:configure\r'
+  autoreconf --force --install
+  ./configure --enable-tests $COVERAGE_OPT \
+    --disable-silent-rules \
+    --with-libsass-include=$SASS_LIBSASS_PATH \
+    --with-libsass-lib=$TRAVIS_BUILD_DIR/lib \
+    --prefix=$TRAVIS_BUILD_DIR \
+    ${SHARED_OPT}
+  echo -en 'travis_fold:end:configure\r'
+
+  # always rebuild
+  make $MAKE_OPTS clean
+  # does what $BUILD says
+  make $MAKE_OPTS all
+
+  mkdir -p bin
+  cp -af sassc bin
+
+else
+
+  # always rebuild
+  make $MAKE_OPTS clean
+
+  # does what $BUILD says
+  make $MAKE_OPTS all
+
+  # sassc has static as dep
+  echo make $MAKE_OPTS $SASS_SASSC_PATH/bin/sassc
+
+fi
+
+echo successfully compiled sassc
+echo AUTOTOOLS=$AUTOTOOLS COVERAGE=$COVERAGE BUILD=$BUILD
+
+LD_LIBRARY_PATH="$TRAVIS_BUILD_DIR/lib" bin/sassc -v


### PR DESCRIPTION
In reference to https://github.com/sass/libsass/pull/693  
- Add option to show compiled versions
- Update build to match latest libsass master

https://travis-ci.org/mgreter/sassc/builds/43346128

``` bash
$ ./bin/sassc -v
sassc: 3.0.2-2-g6cc2
libsass: 3.0.2-66-g63eb
sass2scss: 1.0.3
```
