### PR TITLE
Dont try to build a real static binary on Mac OS X/Darwin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,12 +97,17 @@ ifeq (Windows,$(UNAME))
 	TARGET = bin/sassc.exe
 endif
 
+STATICFLAG=-static
+ifeq (Darwin,$(UNAME))
+	STATICFLAG=
+endif
+
 all: libsass $(TARGET)
 
 $(TARGET): build-$(BUILD)
 
 build-static: $(OBJECTS) $(LIB_STATIC)
-	$(CC) -static $(LDFLAGS) -o $(TARGET) $^ $(LDLIBS)
+	$(CC) $(STATICFLAG) $(LDFLAGS) -o $(TARGET) $^ $(LDLIBS)
 
 build-shared: $(OBJECTS) $(LIB_SHARED)
 	$(CP) $(LIB_SHARED) bin/


### PR DESCRIPTION
I dont remember the exact details, but AFAIR this is not supported on Darwin. This fixes building on Mac OS X/Darwin.

I build SassC using 

```
SASS_LIBSASS_PATH=../libsass/ make
```

My directory layout is:

```
sassc
 + libsassc 
 + sassc
```

And i am in the sassc/sassc directory when executing the command. This works for me on linux and mac.
