### PR TITLE
Fix issue with input path being overwritten

### DIFF
--- a/sassc.c
+++ b/sassc.c
@@ -100,6 +100,7 @@ int compile_file(struct Sass_Options* options, char* input_path, char* outfile) 
     struct Sass_File_Context* ctx = sass_make_file_context(input_path);
     struct Sass_Context* ctx_out = sass_file_context_get_context(ctx);
     if (outfile) sass_option_set_output_path(options, outfile);
+    sass_option_set_input_path(options, input_path);
     sass_file_context_set_options(ctx, options);
 
     sass_compile_file_context(ctx);


### PR DESCRIPTION
This is a partial fix for https://github.com/sass/sassc/issues/88
Releated libsass PR: https://github.com/sass/libsass/pull/794
