### PR TITLE
Remove the image-path option

### DIFF
--- a/sassc.c
+++ b/sassc.c
@@ -177,7 +177,6 @@ int main(int argc, char** argv) {
     bool generate_source_map = false;
     struct Sass_Options* options = sass_make_options();
     sass_option_set_output_style(options, SASS_STYLE_NESTED);
-    sass_option_set_image_path(options, "images");
     char *include_paths = NULL;
     sass_option_set_precision(options, 5);
 

--- a/sassloop.c
+++ b/sassloop.c
@@ -4,7 +4,7 @@
 #include "libsass/sass_interface.h"
 
 int main(int argc, char** argv)
-{	
+{
 	if (argc < 3) {
 		printf("Usage: sassloop [INPUT FILE] [ITERATIONS]\n");
 		return 0;
@@ -15,7 +15,6 @@ int main(int argc, char** argv)
 		struct sass_file_context* ctx = sass_new_file_context();
 		printf("*** ALLOCATED A NEW CONTEXT\n");
 		ctx->options.include_paths = "";
-		ctx->options.image_path = "images";
 		ctx->options.output_style = SASS_STYLE_NESTED;
 		ctx->input_path = argv[1];
 		printf("*** POPULATED THE CONTEXT\n");
@@ -31,7 +30,7 @@ int main(int argc, char** argv)
 	  else {
 	    printf("Unknown internal error.\n");
 	  }
-		
+
 	  sass_free_file_context(ctx);
 	  printf("*** DEALLOCATED THE CONTEXT\n");
 	  sleep(1);


### PR DESCRIPTION
This PR is the corresponding sassc removal of `image-path` for https://github.com/sass/libsass/pull/834.

/cc @mgreter 