### PR TITLE
Implement all output styles

### DIFF
--- a/sassc.c
+++ b/sassc.c
@@ -131,8 +131,8 @@ struct
     int output_style;
 } style_option_strings[] = {
     { "compressed", SASS_STYLE_COMPRESSED },
-    //{ "compact", SASS_STYLE_COMPACT },
-    //{ "expanded", SASS_STYLE_EXPANDED },
+    { "compact", SASS_STYLE_COMPACT },
+    { "expanded", SASS_STYLE_EXPANDED },
     { "nested", SASS_STYLE_NESTED }
 };
 


### PR DESCRIPTION
Related to https://github.com/sass/libsass/pull/910 and https://github.com/sass/sass-spec/pull/270

- Enable missing output style options