### PR TITLE
Remove static linker flag from build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,17 +103,12 @@ ifeq (Windows,$(UNAME))
 	TARGET = bin/sassc.exe
 endif
 
-STATICFLAG=-static
-ifeq (Darwin,$(UNAME))
-	STATICFLAG=
-endif
-
 all: libsass $(TARGET)
 
 $(TARGET): build-$(BUILD)
 
 build-static: $(OBJECTS) $(LIB_STATIC)
-	$(CC) $(STATICFLAG) $(LDFLAGS) -o $(TARGET) $^ $(LDLIBS)
+	$(CC) $(LDFLAGS) -o $(TARGET) $^ $(LDLIBS)
 
 build-shared: $(OBJECTS) $(LIB_SHARED)
 	$(CP) $(LIB_SHARED) bin/


### PR DESCRIPTION
Needed for plugin loading to compile.
It will still link libsass statically bot not system libs!
Not sure if anyone really uses it, otherwise we would probably need another flag to disable the complete plugin part in libsass. Although it doesn't seem to work on mac anyway, so IMO not a big change!
It now actually links exactly as the automake build!