### PR TITLE
Double free() fault

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,5 @@ Makefile.in
 /m4/lt~obsolete.m4
 /missing
 /stamp-h1
+/compile
+/sassc

--- a/sassc.c
+++ b/sassc.c
@@ -91,7 +91,6 @@ int compile_stdin(struct Sass_Options* options, char* outfile) {
         outfile
     );
     sass_delete_data_context(ctx);
-    free(source_string);
     return ret;
 }
 


### PR DESCRIPTION
`sass_clear_context()` is calling
now `free()` on `source_string`