### PR TITLE
Add _CRT_SECURE_NO_WARNINGS to avoid warning C4996

### DIFF
--- a/sassc.c
+++ b/sassc.c
@@ -6,6 +6,12 @@
 #include <sass_context.h>
 #include "sassc_version.h"
 
+#ifdef _MSC_VER
+#ifndef _CRT_SECURE_NO_WARNINGS
+#define _CRT_SECURE_NO_WARNINGS
+#endif
+#endif
+ 
 #define BUFSIZE 512
 #ifdef _WIN32
 #define PATH_SEP ';'


### PR DESCRIPTION
Follow up to libsass change https://github.com/sass/libsass/pull/1423