### PR TITLE
Features/timer: Proposal adding timer/stopwatch as optional feature to sassc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ before_install:
   - gem install sass
   - git clone https://github.com/sass/libsass.git
   - cd libsass && git submodule init && git submodule update && cd ..
-  - export SASS_LIBSASS_PATH=libsass
+  - export SASS_LIBSASS_PATH=$TRAVIS_BUILD_DIR/libsass
 
 script:
   - ./script/ci-build-libsass

--- a/Makefile
+++ b/Makefile
@@ -140,7 +140,7 @@ ifeq (,$(PREFIX))
 	endif
 endif
 
-SOURCES = sassc.c
+SOURCES = sassc.c timer.c
 
 # shell invocation makes problem in mingw64
 LIB_STATIC = $(SASS_LIBSASS_PATH)/lib/libsass.a

--- a/Makefile.am
+++ b/Makefile.am
@@ -17,7 +17,7 @@ AM_LDFLAGS  = $(AM_COPT) $(AM_COVLDFLAGS)
 # we have moved the files to src folder
 AM_CPPFLAGS += -I$(top_srcdir)
 
-SOURCES = sassc.c
+SOURCES = sassc.c timer.c
 if COMPILER_IS_MINGW32
   SOURCES += res/libsass.rc
   AM_CXXFLAGS += -std=gnu++0x

--- a/sassc.c
+++ b/sassc.c
@@ -299,7 +299,7 @@ int main(int argc, char** argv) {
     free(include_paths);
 
 	if (start_timestamp > 0) {
-		printf("Compile time: %u (ms)\n", (GetTimeMs64() - start_timestamp));
+		printf("Compile time: %" PRIu64 " (ms)\n", (GetTimeMs64() - start_timestamp));
 	}
 
     return result;

--- a/sassc.c
+++ b/sassc.c
@@ -299,7 +299,7 @@ int main(int argc, char** argv) {
     free(include_paths);
 
 	if (start_timestamp > 0) {
-		printf("Compile time: %" PRIu64 " (ms)\n", (GetTimeMs64() - start_timestamp));
+		printf("Compile time: %llu (ms)\n", (GetTimeMs64() - start_timestamp));
 	}
 
     return result;

--- a/sassc.c
+++ b/sassc.c
@@ -1,3 +1,9 @@
+#ifdef _MSC_VER
+#ifndef _CRT_SECURE_NO_WARNINGS
+#define _CRT_SECURE_NO_WARNINGS 1
+#endif
+#endif
+
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
@@ -199,7 +205,11 @@ int main(int argc, char** argv) {
             break;
         case 'I':
             if (!include_paths) {
-                include_paths = strdup(optarg);
+#ifdef _MSC_VER
+				include_paths = _strdup(optarg);
+#else
+				include_paths = strdup(optarg);
+#endif
             } else {
                 char *old_paths = include_paths;
                 include_paths = malloc(strlen(old_paths) + 1 + strlen(optarg) + 1);

--- a/sassc.c
+++ b/sassc.c
@@ -11,6 +11,7 @@
 #include <sass2scss.h>
 #include <sass_context.h>
 #include "sassc_version.h"
+#include "timer.h"
 
 #define BUFSIZE 512
 #ifdef _WIN32
@@ -163,7 +164,8 @@ void print_usage(char* argv0) {
     printf("   -m, --sourcemap         Emit source map.\n");
     printf("   -M, --omit-map-comment  Omits the source map url comment.\n");
     printf("   -p, --precision         Set the precision for numbers.\n");
-    printf("   -v, --version           Display compiled versions.\n");
+	printf("   -w, --stopwatch         Use stopwatch to time compiler.\n");
+	printf("   -v, --version           Display compiled versions.\n");
     printf("   -h, --help              Display this help message.\n");
     printf("\n");
 }
@@ -177,6 +179,7 @@ int main(int argc, char** argv) {
     char *outfile = 0;
     int from_stdin = 0;
     bool generate_source_map = false;
+	uint64 start_timestamp = 0;
     struct Sass_Options* options = sass_make_options();
     sass_option_set_output_style(options, SASS_STYLE_NESTED);
     char *include_paths = NULL;
@@ -194,11 +197,12 @@ int main(int argc, char** argv) {
         { "sourcemap",          no_argument,       0, 'm' },
         { "omit-map-comment",   no_argument,       0, 'M' },
         { "precision",          required_argument, 0, 'p' },
+		{ "stopwatch",			no_argument,	   0, 'w' },
         { "version",            no_argument,       0, 'v' },
         { "help",               no_argument,       0, 'h' },
         { NULL,                 0,                 NULL, 0}
     };
-    while ((c = getopt_long(argc, argv, "vhslmMt:I:", long_options, &long_index)) != -1) {
+    while ((c = getopt_long(argc, argv, "vwhslmMt:I:", long_options, &long_index)) != -1) {
         switch (c) {
         case 's':
             from_stdin = 1;
@@ -246,6 +250,9 @@ int main(int argc, char** argv) {
             sass_option_set_precision(options, atoi(optarg)); // TODO: make this more robust
             if (sass_option_get_precision(options) < 0) sass_option_set_precision(options, 5);
             break;
+		case 'w':
+			start_timestamp = GetTimeMs64();
+			break;
         case 'v':
             print_version(argv[0]);
             return 0;
@@ -290,6 +297,10 @@ int main(int argc, char** argv) {
     }
 
     free(include_paths);
+
+	if (start_timestamp > 0) {
+		printf("Compile time: %u (ms)\n", (GetTimeMs64() - start_timestamp));
+	}
 
     return result;
 }

--- a/timer.c
+++ b/timer.c
@@ -33,7 +33,7 @@ uint64 GetTimeMs64()
 	/* Linux */
 	struct timeval tv;
 
-	gettimeofday(&tv, NULL);
+	gettimeofday(&tv, 0);
 
 	uint64 ret = tv.tv_usec;
 	/* Convert from micro seconds (10^-6) to milliseconds (10^-3) */

--- a/timer.c
+++ b/timer.c
@@ -1,0 +1,49 @@
+
+#include "timer.h"
+
+#ifdef _WIN32
+#include <Windows.h>
+#else
+#include <sys/time.h>
+#include <ctime>
+#endif
+
+
+/* Returns the amount of milliseconds elapsed since the UNIX epoch. Works on both
+* windows and linux. */
+
+uint64 GetTimeMs64()
+{
+#ifdef _WIN32
+	/* Windows */
+	FILETIME ft;
+	LARGE_INTEGER li;
+
+	/* Get the amount of 100 nano seconds intervals elapsed since January 1, 1601 (UTC) and copy it
+	* to a LARGE_INTEGER structure. */
+	GetSystemTimeAsFileTime(&ft);
+	li.LowPart = ft.dwLowDateTime;
+	li.HighPart = ft.dwHighDateTime;
+
+	uint64 ret = li.QuadPart;
+	ret -= 116444736000000000LL; /* Convert from file time to UNIX epoch time. */
+	ret /= 10000; /* From 100 nano seconds (10^-7) to 1 millisecond (10^-3) intervals */
+
+	return ret;
+#else
+	/* Linux */
+	struct timeval tv;
+
+	gettimeofday(&tv, NULL);
+
+	uint64 ret = tv.tv_usec;
+	/* Convert from micro seconds (10^-6) to milliseconds (10^-3) */
+	ret /= 1000;
+
+	/* Adds the seconds (10^0) after converting them to milliseconds (10^-3) */
+	ret += (tv.tv_sec * 1000);
+
+	return ret;
+#endif
+}
+

--- a/timer.c
+++ b/timer.c
@@ -5,7 +5,6 @@
 #include <Windows.h>
 #else
 #include <sys/time.h>
-#include <ctime>
 #endif
 
 

--- a/timer.h
+++ b/timer.h
@@ -1,0 +1,20 @@
+#ifndef SASSC_TIMER_H
+#define SASSC_TIMER_H
+
+/*
+
+ Source reference: 
+ Andreas Bonini via StackOverflow
+ http://stackoverflow.com/questions/1861294/how-to-calculate-execution-time-of-a-code-snippet-in-c/1861337#1861337
+ 
+*/
+
+
+/* Remove if already defined */
+typedef long long int64; 
+typedef unsigned long long uint64;
+
+extern uint64 GetTimeMs64();
+
+
+#endif /* SASSC_TIMER_H */

--- a/timer.h
+++ b/timer.h
@@ -1,6 +1,8 @@
 #ifndef SASSC_TIMER_H
 #define SASSC_TIMER_H
 
+#include <inttypes.h>
+
 /*
 
  Source reference: 

--- a/win/posix/getopt.c
+++ b/win/posix/getopt.c
@@ -344,8 +344,16 @@ getopt_internal(int nargc, char * const *nargv, const char *options,
 	 * CV, 2009-12-14: Check POSIXLY_CORRECT anew if optind == 0 or
 	 *                 optreset != 0 for GNU compatibility.
 	 */
-	if (posixly_correct == -1 || optreset != 0)
+	if (posixly_correct == -1 || optreset != 0) {
+#ifdef _MSC_VER
+		size_t requiredSize;
+
+		getenv_s(&requiredSize, NULL, 0, "POSIXLY_CORRECT");
+		posixly_correct = requiredSize > 0;
+#else
 		posixly_correct = (getenv("POSIXLY_CORRECT") != NULL);
+#endif
+	}
 	if (*options == '-')
 		flags |= FLAG_ALLARGS;
 	else if (posixly_correct || *options == '+')

--- a/win/sassc.vcxproj
+++ b/win/sassc.vcxproj
@@ -156,6 +156,7 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClCompile Include="..\timer.c" />
     <ClCompile Include="posix\getopt.c" />
     <ClCompile Include="..\..\*.cpp" />
     <ClCompile Include="..\..\*.c" />


### PR DESCRIPTION
Output is simple:
   Compile time: 101 (ms)

Currently I've added the timing arround both Compile (StdIn/StdOut) and CompileFile. But this means that the printf can mess up when compiling to StdOut?

I've only tested it on Windows x64 so when Appveyor fails I will look into Linux part.

This "features/timer" branch is created on top of the winx64_fixes branch. Is this workable?

Review comments are welcome.
