### PR TITLE
Build: Upgrades VS files to support VS2015

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,3 @@
-bin/*
-*.o
-*.gem
-*.res
-.sass-cache
-
 a.out
 .DS_Store
 
@@ -31,3 +25,27 @@ Makefile.in
 /stamp-h1
 /compile
 /sassc
+
+# Build stuff
+
+*.o
+*.gem
+*.res
+*.o
+*.lo
+*.so
+*.dll
+*.a
+*.suo
+*.sdf
+*.opensdf
+a.out
+libsass.js
+tester
+tester.exe
+build/
+config.h.in*
+lib/pkgconfig/
+.sass-cache
+
+win/bin

--- a/win/sassc.vcxproj
+++ b/win/sassc.vcxproj
@@ -8,10 +8,10 @@
     <LIBSASS_HEADERS_DIR>$(LIBSASS_DIR)\src</LIBSASS_HEADERS_DIR>
   </PropertyGroup>
   <Target Name="GitVersion">
-    <Exec Command="git -C .. describe --abbrev=4 --dirty --always --tags" ConsoleToMSBuild="true">
+    <Exec Command="git -C .. describe --abbrev=4 --dirty --always --tags" LogStandardErrorAsError="true" ContinueOnError="true">
       <Output TaskParameter="ConsoleOutput" PropertyName="SASSC_VERSION" />
     </Exec>
-    <Exec Command="git -C $(LIBSASS_DIR) describe --abbrev=4 --dirty --always --tags" ConsoleToMSBuild="true">
+    <Exec Command="git -C $(LIBSASS_DIR) describe --abbrev=4 --dirty --always --tags" LogStandardErrorAsError="true" ContinueOnError="true">
       <Output TaskParameter="ConsoleOutput" PropertyName="LIBSASS_VERSION" />
     </Exec>
   </Target>

--- a/win/sassc.vcxproj
+++ b/win/sassc.vcxproj
@@ -1,5 +1,36 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="14.0" DefaultTargets="GitVersion;Main" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <SASSC_VERSION>[NA]</SASSC_VERSION>
+    <LIBSASS_VERSION>[NA]</LIBSASS_VERSION>
+    <LIBSASS_DIR>..\..</LIBSASS_DIR>
+    <LIBSASS_SRC_DIR>$(LIBSASS_DIR)\src</LIBSASS_SRC_DIR>
+    <LIBSASS_HEADERS_DIR>$(LIBSASS_DIR)\src</LIBSASS_HEADERS_DIR>
+  </PropertyGroup>
+  <Target Name="GitVersion">
+    <Exec Command="git -C .. describe --abbrev=4 --dirty --always --tags" ConsoleToMSBuild="true">
+      <Output TaskParameter="ConsoleOutput" PropertyName="SASSC_VERSION" />
+    </Exec>
+    <Exec Command="git -C $(LIBSASS_DIR) describe --abbrev=4 --dirty --always --tags" ConsoleToMSBuild="true">
+      <Output TaskParameter="ConsoleOutput" PropertyName="LIBSASS_VERSION" />
+    </Exec>
+  </Target>
+  <Target Name="VersionMacros">
+    <ItemGroup>
+      <ClCompile>
+        <PreprocessorDefinitions>%(PreprocessorDefinitions);SASSC_VERSION="$(SASSC_VERSION)"</PreprocessorDefinitions>
+      </ClCompile>
+      <ClCompile>
+        <PreprocessorDefinitions>%(PreprocessorDefinitions);LIBSASS_VERSION="$(LIBSASS_VERSION)"</PreprocessorDefinitions>
+      </ClCompile>
+    </ItemGroup>
+  </Target>
+  <Target Name="Main">
+    <Message Text="sassc: $(SASSC_VERSION)" />
+    <Message Text="libsass: $(LIBSASS_VERSION)" />
+    <CallTarget Targets="VersionMacros" />
+    <CallTarget Targets="Build" />
+  </Target>
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -18,37 +49,31 @@
       <Platform>x64</Platform>
     </ProjectConfiguration>
   </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Label="Globals">
     <ProjectGuid>{E4030474-AFC9-4CC6-BEB6-D846F631502B}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>libsass</RootNamespace>
   </PropertyGroup>
-  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+  <PropertyGroup Label="Common Properties">
     <ConfigurationType>Application</ConfigurationType>
+    <CharacterSet>Unicode</CharacterSet>
+    <TargetName>sassc</TargetName>
+    <OutDir>$(SolutionDir)..\bin\</OutDir>
+    <IntDir>$(SolutionDir)..\bin\$(Configuration)\obj\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Label="VS2013 toolset selection" Condition="'$(VisualStudioVersion)' == '12.0'">
+    <PlatformToolset>v120</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Label="VS2015 toolset selection" Condition="'$(VisualStudioVersion)' == '14.0'">
+    <PlatformToolset>v140</PlatformToolset>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32' Or '$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v120</PlatformToolset>
-    <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
-    <ConfigurationType>Application</ConfigurationType>
-    <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v120</PlatformToolset>
-    <CharacterSet>Unicode</CharacterSet>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
-    <ConfigurationType>Application</ConfigurationType>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32' Or '$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v120</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
-    <CharacterSet>Unicode</CharacterSet>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
-    <ConfigurationType>Application</ConfigurationType>
-    <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v120</PlatformToolset>
-    <WholeProgramOptimization>true</WholeProgramOptimization>
-    <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
@@ -66,33 +91,15 @@
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32' Or '$(Configuration)|$(Platform)' == 'Debug|x64'">
     <LinkIncremental>true</LinkIncremental>
-    <TargetName>sassc</TargetName>
-    <OutDir>$(SolutionDir)..\bin\</OutDir>
-    <IntDir>$(SolutionDir)..\bin\obj\</IntDir>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <LinkIncremental>true</LinkIncremental>
-    <TargetName>sassc</TargetName>
-    <OutDir>$(SolutionDir)bin\Debug\</OutDir>
-    <IntDir>$(SolutionDir)bin\Debug\obj\</IntDir>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|Win32' Or '$(Configuration)|$(Platform)' == 'Release|x64'">
     <LinkIncremental>false</LinkIncremental>
-    <TargetName>sassc</TargetName>
-    <OutDir>$(SolutionDir)..\bin\</OutDir>
-    <IntDir>$(SolutionDir)..\bin\obj</IntDir>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <LinkIncremental>false</LinkIncremental>
-    <TargetName>sassc</TargetName>
-    <OutDir>$(SolutionDir)bin\</OutDir>
-    <IntDir>$(SolutionDir)bin\obj\</IntDir>
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>
-      <AdditionalIncludeDirectories>..;posix;..\..\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..;posix;..\..\include;..\..\src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
@@ -155,15 +162,13 @@
       <OptimizeReferences>true</OptimizeReferences>
     </Link>
   </ItemDefinitionGroup>
+  <Import Project="$(LIBSASS_DIR)\win\libsass.targets" />
   <ItemGroup>
     <ClCompile Include="posix\getopt.c" />
-    <ClCompile Include="..\..\*.cpp" />
-    <ClCompile Include="..\..\*.c" />
     <ClCompile Include="..\sassc.c" />
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="..\..\*.hpp" />
-    <ClInclude Include="..\..\*.h" />
+    <ClInclude Include="posix\getopt.h" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/win/sassc.vcxproj.filters
+++ b/win/sassc.vcxproj.filters
@@ -1,0 +1,325 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup>
+    <Filter Include="Resource Files">
+      <UniqueIdentifier>{67DA6AB6-F800-4c08-8B7A-83BB121AAD01}</UniqueIdentifier>
+      <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
+    </Filter>
+    <Filter Include="Header Files">
+      <UniqueIdentifier>{dbdf7aff-4ba7-44ea-a850-2ba5cef9ce28}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Source Files">
+      <UniqueIdentifier>{80280903-f392-429c-9812-09bb4fdd4b21}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="LibSass">
+      <UniqueIdentifier>{b9d61faa-a8b4-44e5-9e74-58d686989973}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="LibSass\Header Files">
+      <UniqueIdentifier>{93995380-89BD-4b04-88EB-625FBE52EBFB}</UniqueIdentifier>
+      <Extensions>h;hh;hpp;hxx;hm;inl;inc;xsd</Extensions>
+    </Filter>
+    <Filter Include="LibSass\Source Files">
+      <UniqueIdentifier>{4FC737F1-C7A5-4376-A066-2A32D752A2FF}</UniqueIdentifier>
+      <Extensions>cpp;c;cc;cxx;def;odl;idl;hpj;bat;asm;asmx</Extensions>
+    </Filter>
+  </ItemGroup>
+  <ItemGroup Label="Headers">
+    <ClInclude Include="posix\getopt.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup Label="Sources">
+    <ClCompile Include="..\sassc.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="posix\getopt.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup Label="LibSass Headers">
+    <ClInclude Include="$(LIBSASS_HEADERS_DIR)\ast.hpp">
+      <Filter>LibSass\Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="$(LIBSASS_HEADERS_DIR)\ast_def_macros.hpp">
+      <Filter>LibSass\Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="$(LIBSASS_HEADERS_DIR)\ast_factory.hpp">
+      <Filter>LibSass\Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="$(LIBSASS_HEADERS_DIR)\ast_fwd_decl.hpp">
+      <Filter>LibSass\Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="$(LIBSASS_HEADERS_DIR)\backtrace.hpp">
+      <Filter>LibSass\Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="$(LIBSASS_HEADERS_DIR)\base64vlq.hpp">
+      <Filter>LibSass\Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="$(LIBSASS_HEADERS_DIR)\bind.hpp">
+      <Filter>LibSass\Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="$(LIBSASS_SRC_DIR)\cencode.h">
+      <Filter>LibSass\Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="$(LIBSASS_HEADERS_DIR)\color_maps.hpp">
+      <Filter>LibSass\Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="$(LIBSASS_HEADERS_DIR)\constants.hpp">
+      <Filter>LibSass\Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="$(LIBSASS_HEADERS_DIR)\context.hpp">
+      <Filter>LibSass\Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="$(LIBSASS_HEADERS_DIR)\cssize.hpp">
+      <Filter>LibSass\Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="$(LIBSASS_HEADERS_DIR)\debug.hpp">
+      <Filter>LibSass\Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="$(LIBSASS_HEADERS_DIR)\emitter.hpp">
+      <Filter>LibSass\Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="$(LIBSASS_HEADERS_DIR)\environment.hpp">
+      <Filter>LibSass\Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="$(LIBSASS_HEADERS_DIR)\error_handling.hpp">
+      <Filter>LibSass\Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="$(LIBSASS_HEADERS_DIR)\eval.hpp">
+      <Filter>LibSass\Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="$(LIBSASS_HEADERS_DIR)\expand.hpp">
+      <Filter>LibSass\Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="$(LIBSASS_HEADERS_DIR)\extend.hpp">
+      <Filter>LibSass\Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="$(LIBSASS_HEADERS_DIR)\file.hpp">
+      <Filter>LibSass\Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="$(LIBSASS_HEADERS_DIR)\functions.hpp">
+      <Filter>LibSass\Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="$(LIBSASS_HEADERS_DIR)\inspect.hpp">
+      <Filter>LibSass\Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="$(LIBSASS_HEADERS_DIR)\json.hpp">
+      <Filter>LibSass\Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="$(LIBSASS_HEADERS_DIR)\kwd_arg_macros.hpp">
+      <Filter>LibSass\Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="$(LIBSASS_HEADERS_DIR)\lexer.hpp">
+      <Filter>LibSass\Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="$(LIBSASS_HEADERS_DIR)\listize.hpp">
+      <Filter>LibSass\Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="$(LIBSASS_HEADERS_DIR)\mapping.hpp">
+      <Filter>LibSass\Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="$(LIBSASS_HEADERS_DIR)\memory_manager.hpp">
+      <Filter>LibSass\Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="$(LIBSASS_HEADERS_DIR)\node.hpp">
+      <Filter>LibSass\Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="$(LIBSASS_HEADERS_DIR)\operation.hpp">
+      <Filter>LibSass\Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="$(LIBSASS_HEADERS_DIR)\output.hpp">
+      <Filter>LibSass\Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="$(LIBSASS_HEADERS_DIR)\parser.hpp">
+      <Filter>LibSass\Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="$(LIBSASS_HEADERS_DIR)\paths.hpp">
+      <Filter>LibSass\Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="$(LIBSASS_HEADERS_DIR)\plugins.hpp">
+      <Filter>LibSass\Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="$(LIBSASS_HEADERS_DIR)\position.hpp">
+      <Filter>LibSass\Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="$(LIBSASS_HEADERS_DIR)\prelexer.hpp">
+      <Filter>LibSass\Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="$(LIBSASS_HEADERS_DIR)\remove_placeholders.hpp">
+      <Filter>LibSass\Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="$(LIBSASS_HEADERS_DIR)\sass_util.hpp">
+      <Filter>LibSass\Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="$(LIBSASS_HEADERS_DIR)\source_map.hpp">
+      <Filter>LibSass\Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="$(LIBSASS_HEADERS_DIR)\subset_map.hpp">
+      <Filter>LibSass\Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="$(LIBSASS_HEADERS_DIR)\to_c.hpp">
+      <Filter>LibSass\Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="$(LIBSASS_HEADERS_DIR)\to_string.hpp">
+      <Filter>LibSass\Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="$(LIBSASS_HEADERS_DIR)\to_value.hpp">
+      <Filter>LibSass\Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="$(LIBSASS_HEADERS_DIR)\units.hpp">
+      <Filter>LibSass\Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="$(LIBSASS_HEADERS_DIR)\utf8.h">
+      <Filter>LibSass\Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="$(LIBSASS_HEADERS_DIR)\utf8\checked.h">
+      <Filter>LibSass\Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="$(LIBSASS_HEADERS_DIR)\utf8\core.h">
+      <Filter>LibSass\Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="$(LIBSASS_HEADERS_DIR)\utf8\unchecked.h">
+      <Filter>LibSass\Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="$(LIBSASS_HEADERS_DIR)\utf8_string.hpp">
+      <Filter>LibSass\Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="$(LIBSASS_HEADERS_DIR)\util.hpp">
+      <Filter>LibSass\Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="$(LIBSASS_HEADERS_DIR)\values.hpp">
+      <Filter>LibSass\Header Files</Filter>
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup Label="LibSass Sources">
+    <ClCompile Include="$(LIBSASS_SRC_DIR)\ast.cpp">
+      <Filter>LibSass\Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="$(LIBSASS_SRC_DIR)\base64vlq.cpp">
+      <Filter>LibSass\Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="$(LIBSASS_SRC_DIR)\bind.cpp">
+      <Filter>LibSass\Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="$(LIBSASS_SRC_DIR)\cencode.c">
+      <Filter>LibSass\Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="$(LIBSASS_SRC_DIR)\color_maps.cpp">
+      <Filter>LibSass\Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="$(LIBSASS_SRC_DIR)\constants.cpp">
+      <Filter>LibSass\Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="$(LIBSASS_SRC_DIR)\context.cpp">
+      <Filter>LibSass\Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="$(LIBSASS_SRC_DIR)\cssize.cpp">
+      <Filter>LibSass\Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="$(LIBSASS_SRC_DIR)\emitter.cpp">
+      <Filter>LibSass\Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="$(LIBSASS_SRC_DIR)\environment.cpp">
+      <Filter>LibSass\Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="$(LIBSASS_SRC_DIR)\error_handling.cpp">
+      <Filter>LibSass\Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="$(LIBSASS_SRC_DIR)\eval.cpp">
+      <Filter>LibSass\Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="$(LIBSASS_SRC_DIR)\expand.cpp">
+      <Filter>LibSass\Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="$(LIBSASS_SRC_DIR)\extend.cpp">
+      <Filter>LibSass\Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="$(LIBSASS_SRC_DIR)\file.cpp">
+      <Filter>LibSass\Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="$(LIBSASS_SRC_DIR)\functions.cpp">
+      <Filter>LibSass\Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="$(LIBSASS_SRC_DIR)\inspect.cpp">
+      <Filter>LibSass\Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="$(LIBSASS_SRC_DIR)\json.cpp">
+      <Filter>LibSass\Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="$(LIBSASS_SRC_DIR)\lexer.cpp">
+      <Filter>LibSass\Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="$(LIBSASS_SRC_DIR)\listize.cpp">
+      <Filter>LibSass\Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="$(LIBSASS_SRC_DIR)\memory_manager.cpp">
+      <Filter>LibSass\Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="$(LIBSASS_SRC_DIR)\node.cpp">
+      <Filter>LibSass\Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="$(LIBSASS_SRC_DIR)\output.cpp">
+      <Filter>LibSass\Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="$(LIBSASS_SRC_DIR)\parser.cpp">
+      <Filter>LibSass\Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="$(LIBSASS_SRC_DIR)\plugins.cpp">
+      <Filter>LibSass\Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="$(LIBSASS_SRC_DIR)\position.cpp">
+      <Filter>LibSass\Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="$(LIBSASS_SRC_DIR)\prelexer.cpp">
+      <Filter>LibSass\Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="$(LIBSASS_SRC_DIR)\remove_placeholders.cpp">
+      <Filter>LibSass\Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="$(LIBSASS_SRC_DIR)\sass.cpp">
+      <Filter>LibSass\Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="$(LIBSASS_SRC_DIR)\sass_interface.cpp">
+      <Filter>LibSass\Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="$(LIBSASS_SRC_DIR)\sass_context.cpp">
+      <Filter>LibSass\Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="$(LIBSASS_SRC_DIR)\sass_functions.cpp">
+      <Filter>LibSass\Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="$(LIBSASS_SRC_DIR)\sass_util.cpp">
+      <Filter>LibSass\Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="$(LIBSASS_SRC_DIR)\sass_values.cpp">
+      <Filter>LibSass\Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="$(LIBSASS_SRC_DIR)\sass2scss.cpp">
+      <Filter>LibSass\Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="$(LIBSASS_SRC_DIR)\source_map.cpp">
+      <Filter>LibSass\Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="$(LIBSASS_SRC_DIR)\to_c.cpp">
+      <Filter>LibSass\Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="$(LIBSASS_SRC_DIR)\to_string.cpp">
+      <Filter>LibSass\Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="$(LIBSASS_SRC_DIR)\to_value.cpp">
+      <Filter>LibSass\Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="$(LIBSASS_SRC_DIR)\units.cpp">
+      <Filter>LibSass\Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="$(LIBSASS_SRC_DIR)\utf8_string.cpp">
+      <Filter>LibSass\Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="$(LIBSASS_SRC_DIR)\util.cpp">
+      <Filter>LibSass\Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="$(LIBSASS_SRC_DIR)\values.cpp">
+      <Filter>LibSass\Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
* This enables LibSass CI to use `libsass\sassc\win\sassc.sln`, which
  produces `sassc.exe`, while `libsass\win\libsass.sln` will produce
  `libsass.dll` (or static `libsass.lib`, if sets environment variable:
  `LIBSASS_STATIC_LIB` to `1`). Related PR: sass/libsass#1439.
* Shares the same source tree as `libsass.vcxproj` using common
 `libsass.targets`.
* Backward compatible for VS2013.