### PR TITLE
Docs: Adds Unix and Windows instructions

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -31,61 +31,13 @@ Weizenbaum (@nex3) and Chris Eppstein (@chriseppstein).
 
 For more information about Sass itself, please visit http://sass-lang.com
 
-Building
---------
+Documentation
+-------------
 
-To build SassC, you must have either local copy of the libsass source or it must be installed into your system. For development, please use the source version. You must then setup an environment variable pointing to the libsass folder, like:
-  
-    export SASS_LIBSASS_PATH=/Users/you/path/libsass
-  
-The executable will be in the bin folder. To run it, simply try something like
-
-    ./bin/sassc [input file] > output.css
-
-Step-by-step
-------------
-
-1) Clone the libsass repo:
-
-    git clone https://github.com/sass/libsass.git
-
-2) Edit your .bash_profile to include libsass directory:
-
-    export SASS_LIBSASS_PATH=/Users/you/path/libsass
-
-3) Clone the sassC repo
-
-    git clone https://github.com/sass/sassc.git
-
-4) cd into the sassC repo
-
-    cd ./sassc
-
-5) Type 'make'
-
-    make
-
-6) Job done!
-
-
-Test
-----
-
-The official libsass/sassc test suite is located at http://github.com/sass/sass-spec. It's a specialized project just to ensure that Sass works as expected. First, go clone (and ensure its up-to-date) the sass-spec repo. THEN, you must setup an environment variable to point to the spec folder. Also, if you want to test against the lastest libsass, you MUST define the location of a copy of the libsass repo.
-
-For instance, this is in my profile.
-
-    export SASS_SPEC_PATH=/Users/you/dev/sass/sass-spec
-    export SASS_SASSC_PATH=/Users/you/dev/sass/sassc
-    export SASS_LIBSASS_PATH=/Users/you/dev/sass/libsass
-
-Then, run the SassC specific tests this way:
-
-    make test
-
-Or, if you want to run the whole SassSpec suite
-
-    make test_spec
+* [Building on Unix](docs/building/unix-instructions.md)
+* [Building on Windows](docs/building/windows-instructions.md)
+* [Testing on Unix](docs/testing/unix-instructions.md)
+* [Testing on Windows](docs/testing/windows-instructions.md)
 
 Contribution Agreement
 ----------------------

--- a/docs/building/unix-instructions.md
+++ b/docs/building/unix-instructions.md
@@ -1,0 +1,42 @@
+# Building On Unix
+
+To build SassC, you must have either local copy of the LibSass source or it must be installed into your system. For development, please use the source version. You must then setup an environment variable pointing to the libsass folder, like:
+
+```bash  
+export SASS_LIBSASS_PATH=/Users/you/path/libsass
+```
+
+The executable will be in the bin folder. To run it, simply try something like
+
+```bash
+./bin/sassc [input file] > output.css
+```
+
+# Step-by-step
+
+1. Clone the libsass repo:
+    ```bash
+    git clone https://github.com/sass/libsass.git
+    ```
+
+2. Edit your .bash_profile to include libsass directory:
+    ```bash
+    export SASS_LIBSASS_PATH=/Users/you/path/libsass
+    ```
+
+3. Clone the sassC repo
+    ```bash
+    git clone https://github.com/sass/sassc.git
+    ```
+
+4. cd into the sassC repo
+    ```bash
+    cd ./sassc
+    ```
+
+5. Type 'make'
+   ```bash
+   make
+   ```
+
+6. Job done!

--- a/docs/building/windows-instructions.md
+++ b/docs/building/windows-instructions.md
@@ -1,0 +1,72 @@
+# Building On Windows
+
+To build SassC, the following pre-requisites must be met:
+
+* Local copy of the LibSass source and `sassc` directory in the root of `libsass`.
+* Visual Studio 2013 Express for Desktop or higher.
+
+Additionally, it is recommended to have `git` installed and available in `PATH`, so to deduce the `libsass` and `sassc` version information. For instance, if GitHub for Windows (https://windows.github.com/) is installed, the `PATH` will have an entry resembling: `X:\Users\<YOUR_NAME>\AppData\Local\GitHub\PortableGit_<SOME_GUID>\cmd\` (where `X` is the drive letter of system drive). If `git` is not available, inquiring the LibSass and SassC versions will result in `[NA]`.
+
+## Obtaining the Sources:
+
+If `git` in available in `PATH`, open `cmd` or `PowerShell` and run:
+
+```cmd
+:: clone LibSass repository:
+cd projects
+git clone https://github.com/sass/libsass
+
+:: clone SassC repository inside `libsass\`:
+cd libsass
+git clone https://github.com/sass/sassc
+```
+
+Otherwise download LibSass and SassC sources from github, unzip and arrange so the structure looks like: `libsass\sass`.
+
+## From Visual Studio:
+Open `projects\libsass\sassc\win\sassc.sln`, and do the finger dance `Ctrl+Shift+B` to build `sassc.exe`.
+
+Visual Studio will form the filtered source tree as shown below:
+
+![image](https://cloud.githubusercontent.com/assets/3840695/9313507/f4da01f0-452b-11e5-9276-bed0acc06263.png)
+
+`Header Files` contains the `.h` and `.hpp` files, while `Source Files` covers `.c` and `.cpp` of SassC. `LibSass\Header Files` and `LibSass\Source Files` contain headers and source of LibSass. The other used headers/sources will appear under `External Dependencies`. 
+
+The executable will be in the bin folder under sassc (`sassc\bin\sassc.exe`).
+
+## From Command Line Interface:
+
+Notice that in the following commands:
+
+* If the platform is 32-bit Windows, replace `ProgramFiles(x86)` with `ProgramFiles`.
+* To build with Visual Studio 2015, replace `12.0` with `14.0` in the aforementioned command.
+
+In `cmd`, run:
+
+```cmd
+cd projects\libsass\sassc
+
+:: debug build:
+"%ProgramFiles(x86)%\MSBuild\12.0\Bin\MSBuild" win\sassc.sln
+
+:: or release build:
+"%ProgramFiles(x86)%\MSBuild\12.0\Bin\MSBuild" win\sassc.sln /p:Configuration=Release
+```
+
+In `PowerShell`, the above variant would be:
+
+```powershell
+cd projects\libsass\sassc
+
+# debug build:
+"${env:ProgramFiles(x86)}\MSBuild\12.0\Bin\MSBuild" win\sassc.sln
+
+# or release build:
+"${env:ProgramFiles(x86)}\MSBuild\12.0\Bin\MSBuild" win\sassc.sln /p:Configuration=Release
+```
+
+The executable will be in the bin folder under sassc (`sassc\bin\sassc.exe`). To run it, simply try something like
+
+```cmd
+sassc\binsassc [input file] > output.css
+```

--- a/docs/testing/unix-instructions.md
+++ b/docs/testing/unix-instructions.md
@@ -1,0 +1,23 @@
+# Testing on Unix
+
+The official libsass/sassc test suite is located at http://github.com/sass/sass-spec. It's a specialized project just to ensure that Sass works as expected. First, go clone (and ensure its up-to-date) the sass-spec repo. THEN, you must setup an environment variable to point to the spec folder. Also, if you want to test against the latest libsass, you MUST define the location of a copy of the libsass repo.
+
+For instance, this is in my profile.
+
+```bash
+export SASS_SPEC_PATH=/Users/you/dev/sass/sass-spec
+export SASS_SASSC_PATH=/Users/you/dev/sass/sassc
+export SASS_LIBSASS_PATH=/Users/you/dev/sass/libsass
+```
+
+Then, run the SassC specific tests this way:
+
+```bash
+make test
+```
+
+Or, if you want to run the whole SassSpec suite
+
+```bash
+make test_spec
+```

--- a/docs/testing/windows-instructions.md
+++ b/docs/testing/windows-instructions.md
@@ -1,0 +1,26 @@
+# Testing on Windows
+
+The official libsass/sassc test suite is located at http://github.com/sass/sass-spec. It's a specialized project just to ensure that Sass works as expected. To run the libsass tests, Ruby should be installed in your system. Download https://www.ruby-lang.org/en/downloads/.
+
+After [building SassC](../building/windows-instructions.md), run the SassC specific tests this way:
+
+```cmd
+:: `ruby` should be available in PATH
+:: install a required ruby gem for testing:
+gem install minitest
+
+:: enter the libsass directory
+cd libsass
+
+:: clone sass-spec repo
+git clone https://github.com/sass/sass-spec
+
+:: run entire test suite
+ruby sass-spec/sass-spec.rb -c sassc/bin/sassc -s sass-spec/spec
+```
+
+If you want to skip the tests for known bugs:
+
+```cmd
+ruby sass-spec/sass-spec.rb -c sassc/bin/sassc -s --ignore-todo sass-spec/spec
+```


### PR DESCRIPTION
* Creates `docs/[build/test]ing` directories at the root.
* Purges build and test related instruction from README into:
  `[build/test]ing/unix-instructions`.
* Adds corresponding Windows instructions.
* Adds links in README to markdown files under docs directory.