### PR TITLE
Repo: Moves .gitkeep to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,4 @@ build/
 config.h.in*
 lib/pkgconfig/
 .sass-cache
-
-win/bin
 *.user

--- a/bin/.gitignore
+++ b/bin/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
After build, `git status` was showing files and folders under `bin/`. This PR removes the obsolete `win/bin` rule from .gitignore and renames `bin/.gitkeep` to `bin/.gitignore` with omission rule for all files except for itself.
