### PR TITLE
Fix travis ci static automake lib

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -124,8 +124,10 @@ ifeq ($(UNAME),Darwin)
 endif
 
 ifneq (MinGW,$(UNAME))
-	LDFLAGS += -ldl
-	LDLIBS += -ldl
+	ifneq (FreeBSD,$(UNAME))
+		LDFLAGS += -ldl
+		LDLIBS += -ldl
+	endif
 endif
 
 ifneq ($(BUILD),shared)
@@ -178,10 +180,10 @@ sassc: $(SASSC_EXE)
 
 $(SASSC_EXE): libsass build-$(BUILD)
 
-$(DESTDIR)$(PREFIX):
+$(DESTDIR)$(PREFIX)/:
 	$(MKDIR) $(DESTDIR)$(PREFIX)
 
-$(DESTDIR)$(PREFIX)/bin:
+$(DESTDIR)$(PREFIX)/bin/:
 	$(MKDIR) $(DESTDIR)$(PREFIX)/bin
 
 $(DESTDIR)$(PREFIX)/bin/%: bin/%

--- a/Makefile.am
+++ b/Makefile.am
@@ -24,7 +24,7 @@ if COMPILER_IS_MINGW32
   AM_LDFLAGS += -std=gnu++0x
 else
   AM_CXXFLAGS += -std=c++0x
-  AM_LDFLAGS += -std=c++0x -ldl
+  AM_LDFLAGS += -std=c++0x
 endif
 
 if ENABLE_COVERAGE

--- a/configure.ac
+++ b/configure.ac
@@ -57,6 +57,14 @@ fi
 AM_PROG_AR([])
 LT_INIT([dlopen])
 
+if test "x$is_mingw32" != "xyes"; then
+  dnl The dlopen() function is in the C library for *BSD and in
+  dnl libdl on GLIBC-based systems. Windows uses `LoadLibrary`!
+  AC_SEARCH_LIBS([dlopen], [dl dld], [], [
+    AC_MSG_ERROR([unable to find the dlopen() function])
+  ])
+fi
+
 # check the main assets needed to link to libsass (headers and library)
 AC_CHECK_LIB([sass],[libsass_version],, [AC_MSG_ERROR([unable to find libsass library (use --with-libsass?)])])
 AC_CHECK_HEADERS([sass.h],, [AC_MSG_ERROR([unable to find libsass headers (use --with-libsass?)])])


### PR DESCRIPTION
Problem:
```
configure:15694: checking for libsass_version in -lsass
configure:15719: g++ -o conftest -g -O2  -I/home/travis/build/mgreter/sassc/include  -L/home/travis/build/mgreter/sassc/lib conftest.cpp -lsass   >&5
/home/travis/build/mgreter/sassc/lib/libsass.a(plugins.o): In function `Sass::Plugins::load_plugin(std::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)':
/home/travis/build/mgreter/sassc/libsass/src/plugins.cpp:49: undefined reference to `dlopen'
/home/travis/build/mgreter/sassc/libsass/src/plugins.cpp:52: undefined reference to `dlsym'
/home/travis/build/mgreter/sassc/libsass/src/plugins.cpp:57: undefined reference to `dlsym'
/home/travis/build/mgreter/sassc/libsass/src/plugins.cpp:63: undefined reference to `dlsym'
/home/travis/build/mgreter/sassc/libsass/src/plugins.cpp:69: undefined reference to `dlsym'
/home/travis/build/mgreter/sassc/libsass/src/plugins.cpp:89: undefined reference to `dlerror'
/home/travis/build/mgreter/sassc/libsass/src/plugins.cpp:81: undefined reference to `dlerror'
/home/travis/build/mgreter/sassc/libsass/src/plugins.cpp:82: undefined reference to `dlclose'
collect2: ld returned 1 exit status
```

Fix:
```
if test "x$is_mingw32" != "xyes"; then
  dnl The dlopen() function is in the C library for *BSD and in
  dnl libdl on GLIBC-based systems. Windows uses `LoadLibrary`!
  AC_SEARCH_LIBS([dlopen], [dl dld], [], [
    AC_MSG_ERROR([unable to find the dlopen() function])
  ])
fi
```