### PR TITLE
win: Converts ANSI argv to UTF8 array

### DIFF
--- a/docs/building/windows-instructions.md
+++ b/docs/building/windows-instructions.md
@@ -59,10 +59,10 @@ In `PowerShell`, the above variant would be:
 cd projects\libsass\sassc
 
 # debug build:
-"${env:ProgramFiles(x86)}\MSBuild\12.0\Bin\MSBuild" win\sassc.sln
+&"${env:ProgramFiles(x86)}\MSBuild\12.0\Bin\MSBuild" win\sassc.sln
 
 # or release build:
-"${env:ProgramFiles(x86)}\MSBuild\12.0\Bin\MSBuild" win\sassc.sln /p:Configuration=Release
+&"${env:ProgramFiles(x86)}\MSBuild\12.0\Bin\MSBuild" win\sassc.sln /p:Configuration=Release
 ```
 
 The executable will be in the bin folder under sassc (`sassc\bin\sassc.exe`). To run it, simply try something like


### PR DESCRIPTION
While testing sass/libsass#1774, I found another issue with UTF8 and sassc on Windows: the `char** argv` disregards the Unicode/multibyte characters passed through stdin. Note that sass/libsass#1774 is not dependent on this by the reciprocal is true.

Also added a missing `&` in windows build steps doc.