### PR TITLE
win: Emits version to VS property

### DIFF
--- a/docs/building/windows-instructions.md
+++ b/docs/building/windows-instructions.md
@@ -68,5 +68,5 @@ cd projects\libsass\sassc
 The executable will be in the bin folder under sassc (`sassc\bin\sassc.exe`). To run it, simply try something like
 
 ```cmd
-sassc\binsassc [input file] > output.css
+sassc\bin\sassc [input file] > output.css
 ```

--- a/win/sassc.vcxproj
+++ b/win/sassc.vcxproj
@@ -8,10 +8,10 @@
     <LIBSASS_HEADERS_DIR>$(LIBSASS_DIR)\src</LIBSASS_HEADERS_DIR>
   </PropertyGroup>
   <Target Name="GitVersion">
-    <Exec Command="git -C .. describe --abbrev=4 --dirty --always --tags" LogStandardErrorAsError="true" ContinueOnError="true">
+    <Exec Command="git -C .. describe --abbrev=4 --dirty --always --tags" LogStandardErrorAsError="true" ContinueOnError="true" ConsoleToMSBuild="true">
       <Output TaskParameter="ConsoleOutput" PropertyName="SASSC_VERSION" />
     </Exec>
-    <Exec Command="git -C $(LIBSASS_DIR) describe --abbrev=4 --dirty --always --tags" LogStandardErrorAsError="true" ContinueOnError="true">
+    <Exec Command="git -C $(LIBSASS_DIR) describe --abbrev=4 --dirty --always --tags" LogStandardErrorAsError="true" ContinueOnError="true" ConsoleToMSBuild="true">
       <Output TaskParameter="ConsoleOutput" PropertyName="LIBSASS_VERSION" />
     </Exec>
   </Target>


### PR DESCRIPTION
At present, `sass -v` is returning empty string for libsass and sassc
versions.

Seems like we missed one attribute: `ConsoleToMSBuild="true"`.