### PR TITLE
Add <TargetExt> to vcxproj file

### DIFF
--- a/win/sassc.vcxproj
+++ b/win/sassc.vcxproj
@@ -59,6 +59,7 @@
     <ConfigurationType>Application</ConfigurationType>
     <CharacterSet>Unicode</CharacterSet>
     <TargetName>sassc</TargetName>
+    <TargetExt>sassc.exe</TargetExt>
     <OutDir>$(SolutionDir)..\bin\</OutDir>
     <IntDir>$(SolutionDir)..\bin\$(Configuration)\obj\</IntDir>
   </PropertyGroup>


### PR DESCRIPTION
AppVeyor build produces a warning:

````
       "C:\projects\libsass\sassc\win\sassc.sln" (default target) (1) ->
       "C:\projects\libsass\sassc\win\sassc.vcxproj" (default target) (2) ->
       (DoLinkOutputFilesMatch target) ->
         C:\Program Files (x86)\MSBuild\Microsoft.Cpp\v4.0\V120\Microsoft.CppBuild.targets(1193,5): warning MSB8012: TargetPath(sassc/bin/sassc) does not match the Linker's OutputFile property value (C:\projects\libsass\sassc\bin
\sassc.exe). This may cause your project to build incorrectly. To correct this, please make sure that $(OutDir), $(TargetName) and $(TargetExt) property values match the value specified in %(Link.OutputFile). [C:\projects\libsass
\sassc\win\sassc.vcxproj]

    1 Warning(s)
````