### PR TITLE
Split AST source into multiple compile units

### DIFF
--- a/win/sassc.vcxproj
+++ b/win/sassc.vcxproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="GitVersion;Main" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <SASSC_VERSION>[NA]</SASSC_VERSION>
@@ -100,6 +100,9 @@
   <ItemDefinitionGroup>
     <ClCompile>
       <AdditionalIncludeDirectories>..;posix;..\..\include;..\..\src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AssemblerListingLocation>$(IntDir)/%(RelativeDir)/</AssemblerListingLocation>
+      <ObjectFileName>$(IntDir)/%(RelativeDir)/</ObjectFileName>
+      <XMLDocumentationFileName>$(IntDir)/%(RelativeDir)/</XMLDocumentationFileName>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">

--- a/win/sassc.vcxproj.filters
+++ b/win/sassc.vcxproj.filters
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <Filter Include="Resource Files">
@@ -27,6 +27,42 @@
     <ClInclude Include="posix\getopt.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="$(LIBSASS_INCLUDES_DIR)\sass.h">
+      <Filter>LibSass\Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="$(LIBSASS_INCLUDES_DIR)\sass2scss.h">
+      <Filter>LibSass\Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="$(LIBSASS_INCLUDES_DIR)\sass\base.h">
+      <Filter>LibSass\Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="$(LIBSASS_INCLUDES_DIR)\sass\context.h">
+      <Filter>LibSass\Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="$(LIBSASS_INCLUDES_DIR)\sass\functions.h">
+      <Filter>LibSass\Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="$(LIBSASS_INCLUDES_DIR)\sass\values.h">
+      <Filter>LibSass\Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="$(LIBSASS_INCLUDES_DIR)\sass\version.h">
+      <Filter>LibSass\Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="$(LIBSASS_HEADERS_DIR)\b64\cencode.h">
+      <Filter>LibSass\Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="$(LIBSASS_HEADERS_DIR)\sass.hpp">
+      <Filter>LibSass\Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="$(LIBSASS_HEADERS_DIR)\sass_context.hpp">
+      <Filter>LibSass\Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="$(LIBSASS_HEADERS_DIR)\sass_functions.hpp">
+      <Filter>LibSass\Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="$(LIBSASS_HEADERS_DIR)\sass_values.hpp">
+      <Filter>LibSass\Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup Label="Sources">
     <ClCompile Include="..\sassc.c">
@@ -35,9 +71,36 @@
     <ClCompile Include="posix\getopt.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Condition="$(VisualStudioVersion) &lt; 14.0" Include="$(LIBSASS_SRC_DIR)\c99func.c">
+      <Filter>LibSass\Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup Label="LibSass Headers">
     <ClInclude Include="$(LIBSASS_HEADERS_DIR)\ast.hpp">
+      <Filter>LibSass\Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="$(LIBSASS_HEADERS_DIR)\ast\nodes.hpp">
+      <Filter>LibSass\Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="$(LIBSASS_HEADERS_DIR)\ast\blocks.hpp">
+      <Filter>LibSass\Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="$(LIBSASS_HEADERS_DIR)\ast\values.hpp">
+      <Filter>LibSass\Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="$(LIBSASS_HEADERS_DIR)\ast\selectors.hpp">
+      <Filter>LibSass\Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="$(LIBSASS_HEADERS_DIR)\ast\containers.hpp">
+      <Filter>LibSass\Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="$(LIBSASS_HEADERS_DIR)\ast\statements.hpp">
+      <Filter>LibSass\Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="$(LIBSASS_HEADERS_DIR)\ast\expressions.hpp">
+      <Filter>LibSass\Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="$(LIBSASS_HEADERS_DIR)\ast\common.hpp">
       <Filter>LibSass\Header Files</Filter>
     </ClInclude>
     <ClInclude Include="$(LIBSASS_HEADERS_DIR)\ast_def_macros.hpp">
@@ -56,9 +119,6 @@
       <Filter>LibSass\Header Files</Filter>
     </ClInclude>
     <ClInclude Include="$(LIBSASS_HEADERS_DIR)\bind.hpp">
-      <Filter>LibSass\Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="$(LIBSASS_SRC_DIR)\cencode.h">
       <Filter>LibSass\Header Files</Filter>
     </ClInclude>
     <ClInclude Include="$(LIBSASS_HEADERS_DIR)\color_maps.hpp">
@@ -160,9 +220,6 @@
     <ClInclude Include="$(LIBSASS_HEADERS_DIR)\to_c.hpp">
       <Filter>LibSass\Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="$(LIBSASS_HEADERS_DIR)\to_string.hpp">
-      <Filter>LibSass\Header Files</Filter>
-    </ClInclude>
     <ClInclude Include="$(LIBSASS_HEADERS_DIR)\to_value.hpp">
       <Filter>LibSass\Header Files</Filter>
     </ClInclude>
@@ -193,6 +250,27 @@
   </ItemGroup>
   <ItemGroup Label="LibSass Sources">
     <ClCompile Include="$(LIBSASS_SRC_DIR)\ast.cpp">
+      <Filter>LibSass\Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="$(LIBSASS_SRC_DIR)\ast\nodes.cpp">
+      <Filter>LibSass\Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="$(LIBSASS_SRC_DIR)\ast\blocks.cpp">
+      <Filter>LibSass\Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="$(LIBSASS_SRC_DIR)\ast\values.cpp">
+      <Filter>LibSass\Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="$(LIBSASS_SRC_DIR)\ast\selectors.cpp">
+      <Filter>LibSass\Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="$(LIBSASS_SRC_DIR)\ast\containers.cpp">
+      <Filter>LibSass\Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="$(LIBSASS_SRC_DIR)\ast\statements.cpp">
+      <Filter>LibSass\Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="$(LIBSASS_SRC_DIR)\ast\expressions.cpp">
       <Filter>LibSass\Source Files</Filter>
     </ClCompile>
     <ClCompile Include="$(LIBSASS_SRC_DIR)\base64vlq.cpp">
@@ -279,9 +357,6 @@
     <ClCompile Include="$(LIBSASS_SRC_DIR)\sass.cpp">
       <Filter>LibSass\Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="$(LIBSASS_SRC_DIR)\sass_interface.cpp">
-      <Filter>LibSass\Source Files</Filter>
-    </ClCompile>
     <ClCompile Include="$(LIBSASS_SRC_DIR)\sass_context.cpp">
       <Filter>LibSass\Source Files</Filter>
     </ClCompile>
@@ -301,9 +376,6 @@
       <Filter>LibSass\Source Files</Filter>
     </ClCompile>
     <ClCompile Include="$(LIBSASS_SRC_DIR)\to_c.cpp">
-      <Filter>LibSass\Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="$(LIBSASS_SRC_DIR)\to_string.cpp">
       <Filter>LibSass\Source Files</Filter>
     </ClCompile>
     <ClCompile Include="$(LIBSASS_SRC_DIR)\to_value.cpp">


### PR DESCRIPTION
Accompanying https://github.com/sass/libsass/pull/2060 - Changes MSVC to put object files into subdirectories.