### PR TITLE
sassc hangs when called with no args

### DIFF
--- a/sassc.c
+++ b/sassc.c
@@ -213,6 +213,8 @@ int main(int argc, char** argv) {
 #ifdef _WIN32
     get_argv_utf8(&argc, &argv);
 #endif
+    if (argc == 1) {print_usage(argv[0]); return 0;}
+
     char *outfile = 0;
     int from_stdin = 0;
     bool generate_source_map = false;


### PR DESCRIPTION
This pull just checks if `argc == 1` and if so, prints the usage guide and returns 0 just like calling it with `-h` would.