### PR TITLE
Windows: Add editorconfig and fix filterpaths for latest libsass

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+root = true
+
+[*]
+charset = utf-8
+indent_style = space
+indent_size = 2
+end_of_line = lf
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false
+
+[*.vcxproj,*.vcxproj.filter,*.sln]
+end_of_line = crlf

--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,5 @@ config.h.in*
 lib/pkgconfig/
 .sass-cache
 *.user
+*.db
+*.opendb

--- a/win/sassc.vcxproj
+++ b/win/sassc.vcxproj
@@ -1,11 +1,12 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="GitVersion;Main" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <SASSC_VERSION>[NA]</SASSC_VERSION>
     <LIBSASS_VERSION>[NA]</LIBSASS_VERSION>
-    <LIBSASS_DIR>..\..</LIBSASS_DIR>
+    <LIBSASS_DIR>..\..\libsass</LIBSASS_DIR>
     <LIBSASS_SRC_DIR>$(LIBSASS_DIR)\src</LIBSASS_SRC_DIR>
     <LIBSASS_HEADERS_DIR>$(LIBSASS_DIR)\src</LIBSASS_HEADERS_DIR>
+    <LIBSASS_INCLUDES_DIR>$(LIBSASS_DIR)\include</LIBSASS_INCLUDES_DIR>
   </PropertyGroup>
   <Target Name="GitVersion">
     <Exec Command="git -C .. describe --abbrev=4 --dirty --always --tags" LogStandardErrorAsError="true" ContinueOnError="true" ConsoleToMSBuild="true">
@@ -99,7 +100,7 @@
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>
-      <AdditionalIncludeDirectories>..;posix;..\..\include;..\..\src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..;posix;$(LIBSASS_INCLUDES_DIR);$(LIBSASS_HEADERS_DIR);$(LIBSASS_INCLUDES_DIR)\sass;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AssemblerListingLocation>$(IntDir)/%(RelativeDir)/</AssemblerListingLocation>
       <ObjectFileName>$(IntDir)/%(RelativeDir)/</ObjectFileName>
       <XMLDocumentationFileName>$(IntDir)/%(RelativeDir)/</XMLDocumentationFileName>

--- a/win/sassc.vcxproj.filters
+++ b/win/sassc.vcxproj.filters
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <Filter Include="Resource Files">
@@ -63,6 +63,12 @@
     <ClInclude Include="$(LIBSASS_HEADERS_DIR)\sass_values.hpp">
       <Filter>LibSass\Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="$(LIBSASS_HEADERS_DIR)\check_nesting.hpp">
+      <Filter>LibSass\Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="$(LIBSASS_INCLUDES_DIR)\sass\version.h.in">
+      <Filter>LibSass\Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup Label="Sources">
     <ClCompile Include="..\sassc.c">
@@ -74,33 +80,12 @@
     <ClCompile Condition="$(VisualStudioVersion) &lt; 14.0" Include="$(LIBSASS_SRC_DIR)\c99func.c">
       <Filter>LibSass\Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="$(LIBSASS_SRC_DIR)\check_nesting.cpp">
+      <Filter>LibSass\Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup Label="LibSass Headers">
     <ClInclude Include="$(LIBSASS_HEADERS_DIR)\ast.hpp">
-      <Filter>LibSass\Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="$(LIBSASS_HEADERS_DIR)\ast\nodes.hpp">
-      <Filter>LibSass\Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="$(LIBSASS_HEADERS_DIR)\ast\blocks.hpp">
-      <Filter>LibSass\Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="$(LIBSASS_HEADERS_DIR)\ast\values.hpp">
-      <Filter>LibSass\Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="$(LIBSASS_HEADERS_DIR)\ast\selectors.hpp">
-      <Filter>LibSass\Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="$(LIBSASS_HEADERS_DIR)\ast\containers.hpp">
-      <Filter>LibSass\Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="$(LIBSASS_HEADERS_DIR)\ast\statements.hpp">
-      <Filter>LibSass\Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="$(LIBSASS_HEADERS_DIR)\ast\expressions.hpp">
-      <Filter>LibSass\Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="$(LIBSASS_HEADERS_DIR)\ast\common.hpp">
       <Filter>LibSass\Header Files</Filter>
     </ClInclude>
     <ClInclude Include="$(LIBSASS_HEADERS_DIR)\ast_def_macros.hpp">
@@ -250,27 +235,6 @@
   </ItemGroup>
   <ItemGroup Label="LibSass Sources">
     <ClCompile Include="$(LIBSASS_SRC_DIR)\ast.cpp">
-      <Filter>LibSass\Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="$(LIBSASS_SRC_DIR)\ast\nodes.cpp">
-      <Filter>LibSass\Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="$(LIBSASS_SRC_DIR)\ast\blocks.cpp">
-      <Filter>LibSass\Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="$(LIBSASS_SRC_DIR)\ast\values.cpp">
-      <Filter>LibSass\Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="$(LIBSASS_SRC_DIR)\ast\selectors.cpp">
-      <Filter>LibSass\Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="$(LIBSASS_SRC_DIR)\ast\containers.cpp">
-      <Filter>LibSass\Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="$(LIBSASS_SRC_DIR)\ast\statements.cpp">
-      <Filter>LibSass\Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="$(LIBSASS_SRC_DIR)\ast\expressions.cpp">
       <Filter>LibSass\Source Files</Filter>
     </ClCompile>
     <ClCompile Include="$(LIBSASS_SRC_DIR)\base64vlq.cpp">


### PR DESCRIPTION
- Add missing LIBSASS_INCLUDES_DIR reference
- Fix AdditionalIncludeDirectories so base.h and the other include\sass
files are found
- Update filter paths from latest libsass.targets