### PR TITLE
Remove -ldl flag for OpenBSD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -136,8 +136,10 @@ endif
 
 ifneq (Windows,$(TARGET))
 	ifneq (FreeBSD,$(UNAME))
-		LDFLAGS += -ldl
-		LDLIBS += -ldl
+    ifneq (OpenBSD,$(UNAME))
+			LDFLAGS += -ldl
+			LDLIBS += -ldl
+		endif
 	endif
 endif
 


### PR DESCRIPTION
Flag -ldl is removed only for FreeBSD
Support OpenBSD too