### PR TITLE
Ability to static compile VCR libs

### DIFF
--- a/docs/building/unix-instructions.md
+++ b/docs/building/unix-instructions.md
@@ -24,7 +24,7 @@ The executable will be in the bin folder. To run it, simply try something like
    ```bash
    script/bootstrap
    ```
-Alternately, if you already have libsass cloned or installed, you can edit your .bash_profile to include libsass directory:
+Alternately, if you already have libsass cloned or installed, you can edit your `.bash_profile` to include libsass directory:
     ```bash
     export SASS_LIBSASS_PATH=/Users/you/path/libsass
     ```

--- a/docs/building/windows-instructions.md
+++ b/docs/building/windows-instructions.md
@@ -7,6 +7,8 @@ To build SassC, the following pre-requisites must be met:
 
 Additionally, it is recommended to have `git` installed and available in `PATH`, so to deduce the `libsass` and `sassc` version information. For instance, if GitHub for Windows (https://windows.github.com/) is installed, the `PATH` will have an entry resembling: `X:\Users\<YOUR_NAME>\AppData\Local\GitHub\PortableGit_<SOME_GUID>\cmd\` (where `X` is the drive letter of system drive). If `git` is not available, inquiring the LibSass and SassC versions will result in `[NA]`.
 
+> Note that with `Debug` or `Release` we statically compile VC runtime libraries (e.g. `MSVCP140.dll`) in sassc.exe which result in self-dependent / portable binary that is comparatively large in size. There are separate build configurations for shared runtime: `Debug without static runtime` and `Release without static runtime`, which produce the binary dependent on [VS2015 Redistributable package](https://www.microsoft.com/en-gb/download/details.aspx?id=48145) on the target system. If your target system (where you want to execute sassc.exe) already has VCR (via redistributable pack or Visual Studio itself), it is highly recommended to use this shared configuration. This way when the shared runtime libs receive an updated (performance improvements or bug fixes), the statically compiled image will not be able to take advantage of such updates.
+
 ## Obtaining the Sources:
 
 If `git` in available in `PATH`, open `cmd` or `PowerShell` and run:
@@ -40,17 +42,17 @@ Notice that in the following commands:
 
 * If the platform is 32-bit Windows, replace `ProgramFiles(x86)` with `ProgramFiles`.
 * To build with Visual Studio 2015, replace `12.0` with `14.0` in the aforementioned command.
+* To build 32-bit binary, add `/p:Platform=Win32`.
+* To build 64-bit binary, add `/p:platform=Win64`.
 
-In `cmd`, run:
+For example, in `cmd`, run:
 
 ```cmd
 cd projects\libsass\sassc
 
-:: debug build:
-"%ProgramFiles(x86)%\MSBuild\12.0\Bin\MSBuild" win\sassc.sln
-
-:: or release build:
-"%ProgramFiles(x86)%\MSBuild\12.0\Bin\MSBuild" win\sassc.sln /p:Configuration=Release
+:: 32-bit debug build with statically compiled runtime libs:
+"%ProgramFiles(x86)%\MSBuild\12.0\Bin\MSBuild" win\sassc.sln ^
+/p:Configuration=Debug /p:Platform=Win32
 ```
 
 In `PowerShell`, the above variant would be:
@@ -58,14 +60,12 @@ In `PowerShell`, the above variant would be:
 ```powershell
 cd projects\libsass\sassc
 
-# debug build:
-&"${env:ProgramFiles(x86)}\MSBuild\12.0\Bin\MSBuild" win\sassc.sln
-
-# or release build:
-&"${env:ProgramFiles(x86)}\MSBuild\12.0\Bin\MSBuild" win\sassc.sln /p:Configuration=Release
+# 64-bit release build without statically compiled runtime libs:
+&"${env:ProgramFiles(x86)}\MSBuild\12.0\Bin\MSBuild" win\sassc.sln `
+/p:Configuration='Release without static runtime' /p:Platform=Win64
 ```
 
-You can also override the `LIBSASS_DIR` path by agumenting msbuild properties, such as: `/p:LIBSASS_DIR=../../some/path/leading/to/libsass;Configuration=Release`.
+You can also override the `LIBSASS_DIR` path by augmenting msbuild properties, such as: `/p:LIBSASS_DIR=../../some/path/leading/to/libsass;Configuration=Release`.
 
 The executable will be in the bin folder under sassc (`sassc\bin\sassc.exe`). To run it, simply try something like
 

--- a/win/sassc.sln
+++ b/win/sassc.sln
@@ -5,6 +5,32 @@ VisualStudioVersion = 14.0.25420.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "sassc", "sassc.vcxproj", "{E4030474-AFC9-4CC6-BEB6-D846F631502B}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".SolutionItems", ".SolutionItems", "{66CDE359-E53F-46E9-9B1E-EC30B50D30AF}"
+	ProjectSection(SolutionItems) = preProject
+		..\.editorconfig = ..\.editorconfig
+		..\.gitignore = ..\.gitignore
+		..\.travis.yml = ..\.travis.yml
+		..\appveyor.yml = ..\appveyor.yml
+		..\LICENSE = ..\LICENSE
+		..\Readme.md = ..\Readme.md
+		..\sassc_version.h.in = ..\sassc_version.h.in
+		..\version.sh = ..\version.sh
+	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "docs", "docs", "{5CDEB969-5B7C-4653-BD2D-51D0222BD53D}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "building", "building", "{1B7DFCCC-9806-43B5-8739-5E2D9C55CE42}"
+	ProjectSection(SolutionItems) = preProject
+		..\docs\building\unix-instructions.md = ..\docs\building\unix-instructions.md
+		..\docs\building\windows-instructions.md = ..\docs\building\windows-instructions.md
+	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "testing", "testing", "{4F8D4A73-7FE3-4602-8B46-68FEC98BD69E}"
+	ProjectSection(SolutionItems) = preProject
+		..\docs\testing\unix-instructions.md = ..\docs\testing\unix-instructions.md
+		..\docs\testing\windows-instructions.md = ..\docs\testing\windows-instructions.md
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug without static runtime|Win32 = Debug without static runtime|Win32
@@ -36,5 +62,10 @@ Global
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{5CDEB969-5B7C-4653-BD2D-51D0222BD53D} = {66CDE359-E53F-46E9-9B1E-EC30B50D30AF}
+		{1B7DFCCC-9806-43B5-8739-5E2D9C55CE42} = {5CDEB969-5B7C-4653-BD2D-51D0222BD53D}
+		{4F8D4A73-7FE3-4602-8B46-68FEC98BD69E} = {5CDEB969-5B7C-4653-BD2D-51D0222BD53D}
 	EndGlobalSection
 EndGlobal

--- a/win/sassc.sln
+++ b/win/sassc.sln
@@ -1,22 +1,34 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.23107.0
+VisualStudioVersion = 14.0.25420.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "sassc", "sassc.vcxproj", "{E4030474-AFC9-4CC6-BEB6-D846F631502B}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug without static runtime|Win32 = Debug without static runtime|Win32
+		Debug without static runtime|Win64 = Debug without static runtime|Win64
 		Debug|Win32 = Debug|Win32
 		Debug|Win64 = Debug|Win64
+		Release without static runtime|Win32 = Release without static runtime|Win32
+		Release without static runtime|Win64 = Release without static runtime|Win64
 		Release|Win32 = Release|Win32
 		Release|Win64 = Release|Win64
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{E4030474-AFC9-4CC6-BEB6-D846F631502B}.Debug without static runtime|Win32.ActiveCfg = Debug without static runtime|Win32
+		{E4030474-AFC9-4CC6-BEB6-D846F631502B}.Debug without static runtime|Win32.Build.0 = Debug without static runtime|Win32
+		{E4030474-AFC9-4CC6-BEB6-D846F631502B}.Debug without static runtime|Win64.ActiveCfg = Debug without static runtime|x64
+		{E4030474-AFC9-4CC6-BEB6-D846F631502B}.Debug without static runtime|Win64.Build.0 = Debug without static runtime|x64
 		{E4030474-AFC9-4CC6-BEB6-D846F631502B}.Debug|Win32.ActiveCfg = Debug|Win32
 		{E4030474-AFC9-4CC6-BEB6-D846F631502B}.Debug|Win32.Build.0 = Debug|Win32
 		{E4030474-AFC9-4CC6-BEB6-D846F631502B}.Debug|Win64.ActiveCfg = Debug|x64
 		{E4030474-AFC9-4CC6-BEB6-D846F631502B}.Debug|Win64.Build.0 = Debug|x64
+		{E4030474-AFC9-4CC6-BEB6-D846F631502B}.Release without static runtime|Win32.ActiveCfg = Release without static runtime|Win32
+		{E4030474-AFC9-4CC6-BEB6-D846F631502B}.Release without static runtime|Win32.Build.0 = Release without static runtime|Win32
+		{E4030474-AFC9-4CC6-BEB6-D846F631502B}.Release without static runtime|Win64.ActiveCfg = Release without static runtime|x64
+		{E4030474-AFC9-4CC6-BEB6-D846F631502B}.Release without static runtime|Win64.Build.0 = Release without static runtime|x64
 		{E4030474-AFC9-4CC6-BEB6-D846F631502B}.Release|Win32.ActiveCfg = Release|Win32
 		{E4030474-AFC9-4CC6-BEB6-D846F631502B}.Release|Win32.Build.0 = Release|Win32
 		{E4030474-AFC9-4CC6-BEB6-D846F631502B}.Release|Win64.ActiveCfg = Release|x64

--- a/win/sassc.vcxproj
+++ b/win/sassc.vcxproj
@@ -41,12 +41,28 @@
       <Configuration>Debug</Configuration>
       <Platform>x64</Platform>
     </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug without static runtime|Win32">
+      <Configuration>Debug without static runtime</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug without static runtime|x64">
+      <Configuration>Debug without static runtime</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
     <ProjectConfiguration Include="Release|Win32">
       <Configuration>Release</Configuration>
       <Platform>Win32</Platform>
     </ProjectConfiguration>
     <ProjectConfiguration Include="Release|x64">
       <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release without static runtime|Win32">
+      <Configuration>Release without static runtime</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release without static runtime|x64">
+      <Configuration>Release without static runtime</Configuration>
       <Platform>x64</Platform>
     </ProjectConfiguration>
   </ItemGroup>
@@ -69,34 +85,21 @@
   <PropertyGroup Label="VS2015 toolset selection" Condition="'$(VisualStudioVersion)' == '14.0'">
     <PlatformToolset>v140</PlatformToolset>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32' Or '$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
-    <UseDebugLibraries>true</UseDebugLibraries>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32' Or '$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
-    <UseDebugLibraries>false</UseDebugLibraries>
-    <WholeProgramOptimization>true</WholeProgramOptimization>
-  </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <ImportGroup Label="ExtensionSettings">
   </ImportGroup>
-  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-  </ImportGroup>
-  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="PropertySheets">
-    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-  </ImportGroup>
-  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
-    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
-  </ImportGroup>
-  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="PropertySheets">
+  <ImportGroup Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32' Or '$(Configuration)|$(Platform)' == 'Debug|x64'">
+  <PropertyGroup Condition="$(Configuration.StartsWith('Debug'))">
     <LinkIncremental>true</LinkIncremental>
+    <UseDebugLibraries>true</UseDebugLibraries>
   </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|Win32' Or '$(Configuration)|$(Platform)' == 'Release|x64'">
+  <PropertyGroup Condition="$(Configuration.StartsWith('Release'))">
     <LinkIncremental>false</LinkIncremental>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>
@@ -106,58 +109,30 @@
       <XMLDocumentationFileName>$(IntDir)/%(RelativeDir)/</XMLDocumentationFileName>
     </ClCompile>
   </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+  <ItemDefinitionGroup Condition="$(Configuration.StartsWith('Debug'))">
     <ClCompile>
-      <PrecompiledHeader>
-      </PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
+      <PrecompiledHeader></PrecompiledHeader>
       <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions Condition="'$(Platform)'=='Win32'">WIN32;NDEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions Condition="'$(Platform)'=='x64'">WIN64;NDEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <RuntimeLibrary Condition="'$(Configuration)'!='Debug without static runtime'">MultiThreadedDebug</RuntimeLibrary>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
     </Link>
   </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <ClCompile>
-      <PrecompiledHeader>
-      </PrecompiledHeader>
-      <WarningLevel>Level3</WarningLevel>
-      <Optimization>Disabled</Optimization>
-      <PreprocessorDefinitions>WIN32;_DEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-    </ClCompile>
-    <Link>
-      <SubSystem>Console</SubSystem>
-      <GenerateDebugInformation>true</GenerateDebugInformation>
-    </Link>
-  </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+  <ItemDefinitionGroup Condition="$(Configuration.StartsWith('Release'))">
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>
-      <PrecompiledHeader>
-      </PrecompiledHeader>
+      <PrecompiledHeader></PrecompiledHeader>
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-    </ClCompile>
-    <Link>
-      <SubSystem>Console</SubSystem>
-      <GenerateDebugInformation>true</GenerateDebugInformation>
-      <EnableCOMDATFolding>true</EnableCOMDATFolding>
-      <OptimizeReferences>true</OptimizeReferences>
-    </Link>
-  </ItemDefinitionGroup>
-  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <ClCompile>
-      <WarningLevel>Level3</WarningLevel>
-      <PrecompiledHeader>
-      </PrecompiledHeader>
-      <Optimization>MaxSpeed</Optimization>
-      <FunctionLevelLinking>true</FunctionLevelLinking>
-      <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions Condition="'$(Platform)'=='Win32'">WIN32;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions Condition="'$(Platform)'=='x64'">WIN64;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <RuntimeLibrary Condition="'$(Configuration)'!='Release without static runtime'">MultiThreadedDebug</RuntimeLibrary>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>


### PR DESCRIPTION
Add more configurations to static compile VCR libs.

Also:
* simplified the whole configuration matrix logic in `sassc.vcxproj` (bitness x configuration)
* updated the docs accordingly
* added `.SolutionItems` in `sassc.sln` and linked several repo files (`.gitignore`, `README.md` etc.) and docs directory.

Fix #199