### PR TITLE
Increase stack size for MSVC to 4MB

### DIFF
--- a/win/sassc.vcxproj
+++ b/win/sassc.vcxproj
@@ -130,6 +130,7 @@
       <Optimization>MaxSpeed</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
+      <StackReserveSize>4194304</StackReserveSize>
       <PreprocessorDefinitions Condition="'$(Platform)'=='Win32'">WIN32;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PreprocessorDefinitions Condition="'$(Platform)'=='x64'">WIN64;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <RuntimeLibrary Condition="'$(Configuration)'=='Debug'">MultiThreadedDebug</RuntimeLibrary>

--- a/win/sassc.vcxproj.filters
+++ b/win/sassc.vcxproj.filters
@@ -243,6 +243,9 @@
     <ClCompile Include="$(LIBSASS_SRC_DIR)\ast.cpp">
       <Filter>LibSass\Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="$(LIBSASS_SRC_DIR)\ast_fwd_decl.cpp">
+      <Filter>LibSass\Source Files</Filter>
+    </ClCompile>
     <ClCompile Include="$(LIBSASS_SRC_DIR)\base64vlq.cpp">
       <Filter>LibSass\Source Files</Filter>
     </ClCompile>


### PR DESCRIPTION
It's only one MB by default, which we have seen to be too little for some more advanced use cases.