### PR TITLE
Fix optional short source-map argument

### DIFF
--- a/sassc.c
+++ b/sassc.c
@@ -273,7 +273,7 @@ int main(int argc, char** argv) {
         { "help",               no_argument,       0, 'h' },
         { NULL,                 0,                 NULL, 0}
     };
-    while ((c = getopt_long(argc, argv, "vhslm:Map:t:I:P:E:", long_options, &long_index)) != -1) {
+    while ((c = getopt_long(argc, argv, "vhslm::Map:t:I:P:E:", long_options, &long_index)) != -1) {
         switch (c) {
         case 's':
             from_stdin = 1;


### PR DESCRIPTION
> Two colons mean an option takes an optional arg; if there
> is text in the current argv-element (i.e., in the same word
> as the option name itself, for example, "-oarg"), then it
> is returned in optarg, otherwise optarg is set to zero.