### PR TITLE
Fix a minor typo in sassc.c

### DIFF
--- a/sassc.c
+++ b/sassc.c
@@ -58,7 +58,7 @@ int output(int error_status, const char* error_message, const char* output_strin
         if (error_message) {
             fprintf(stderr, "%s", error_message);
         } else {
-            fprintf(stderr, "An error occured; no error message available.\n");
+            fprintf(stderr, "An error occurred; no error message available.\n");
         }
         return 1;
     } else if (output_string) {


### PR DESCRIPTION
The typo was caught by the Debian Lintian tool:

```
I: sassc: spelling-error-in-binary usr/bin/sassc occured occurred
N: 
N:    Lintian found a spelling error in the given binary. Lintian has a list
N:    of common misspellings that it looks for. It does not have a dictionary
N:    like a spelling checker does.
```

Many thanks!