### PR TITLE
Add VERSION file to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,7 @@ script/depcomp
 script/install-sh
 script/ltmain.sh
 script/missing
+VERSION
 .sass-cache
 *.user
 *.db


### PR DESCRIPTION
This file is used to hardcode the version for releases
that are not able to query the version from git directly.
Once generated it can mess up the state for a submodule.