### PR TITLE
remove enabled-shared from sassc instructions

### DIFF
--- a/docs/building/unix-instructions.md
+++ b/docs/building/unix-instructions.md
@@ -162,7 +162,6 @@ cd ..
 ```bash
 cd sassc
 ./configure \
-  --enable-shared \
   --prefix=/usr
 cd ..
 ```


### PR DESCRIPTION
enabled-shared is only an option for the lib, not sassc