### PR TITLE
Makefile:222: recipe for target 'libsass-static' failed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ ifeq ($(SASS_SASSC_PATH),)
 	SASS_SASSC_PATH = $(abspath $(CURDIR))
 endif
 ifeq ($(SASS_LIBSASS_PATH),)
-	SASS_LIBSASS_PATH = $(abspath $(CURDIR)/..)
+	SASS_LIBSASS_PATH = $(abspath $(CURDIR)/../libsass)
 endif
 
 ifeq ($(SASSC_VERSION),)


### PR DESCRIPTION
I had an issue with building sassc via Makefile. I had a clean install (neither libsass nor sass-spec was preinstalled).

My installation proccess:
```sh
$ cd projects/
$ git clone https://github.com/sass/sassc.git
$ cd sassc
$ ./script/bootstrap
$ make
```

What i got:
```sh
make BUILD="static" -C /home/sinclaire/projects
make[1]: Entering directory '/home/sinclaire/projects'
make[1]: *** No targets specified and no makefile found.  Stop.
make[1]: Leaving directory '/home/sinclaire/projects'
Makefile:222: recipe for target 'libsass-static' failed
make: *** [libsass-static] Error 2
```

This PR fixes it.