### PR TITLE
Remove sassc_version.h from source directory

### DIFF
--- a/sassc_version.h
+++ b/sassc_version.h
@@ -1,8 +1,0 @@
-#ifndef SASSC_VERSION_H
-#define SASSC_VERSION_H
-
-#ifndef SASSC_VERSION
-#define SASSC_VERSION "[NA]"
-#endif
-
-#endif


### PR DESCRIPTION
The sassc_version.h should be generated from sassc_version.h.in. If the build directory is out of the source directory, the sassc_version.h is generated in build directory and the original sassc_version.h in source directory is not overwritten. However, the latter is used during the build, resulting in a missing runtime version:

$ sassc --version
sassc: [NA]
libsass: [NA]
sass2scss: 1.1.1
sass: 3.5

Remove sassc_version.h from source directory to ensure that the sassc_version.h in build directory is used during the build.